### PR TITLE
Move pytest to dev dependencies

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -1373,4 +1373,4 @@ test = ["big-O", "importlib-resources", "jaraco.functools", "jaraco.itertools", 
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.8"
-content-hash = "d259e8a72ae22ad52cf5219a3b8da5d96e0edef1d217396482832a8d61a98095"
+content-hash = "fc50cd3d921bf2fa95d78e05cc4c708c91572d2ad216e66a3463e4fd54f31d98"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,7 +46,6 @@ Changelog = "https://github.com/maldoinc/wireup/releases"
 [tool.poetry.dependencies]
 python = "^3.8"
 graphlib2 = { version = "^0.4.7", python = ">=3.8,<3.9" }
-pytest = "^8.3.3"
 
 [tool.poetry.group.dev.dependencies]
 ruff = "0.6.1"
@@ -60,6 +59,7 @@ typing-extensions = "^4.7.1"
 mypy = "1.11.1"
 coverage = "^7.3.2"
 tox = "^4.14.2"
+pytest = "^8.3.3"
 pytest-asyncio = "^0.24.0"
 
 [tool.ruff]


### PR DESCRIPTION
I moved `pytest` from main dependencies to ~~test~~ dev dependencies in pyproject.toml, as it should only be required for testing, not when installing the library as a dependency.

This reduces the dependency footprint for users. Tests continue to run with `make test`, while regular installation no longer pulls in pytest.

**Edit**: I meant dev, not test.