### PR TITLE
Recursively discover interfaces

### DIFF
--- a/test/fixtures.py
+++ b/test/fixtures.py
@@ -14,13 +14,30 @@ class FooBase:
         self.foo = "foo"
 
 
+class FooBaseAnother:
+    def __init__(self):
+        self.foo = "another_foo"
+
+
 class FooBar(FooBase):
     def __init__(self):
         super().__init__()
         self.foo = "bar"
 
 
+class FooBarChild(FooBar):
+    def __init__(self):
+        super().__init__()
+        self.foo = "bar_child"
+
+
 class FooBaz(FooBase):
     def __init__(self):
         super().__init__()
         self.foo = "baz"
+
+
+class FooBarMultipleBases(FooBase, FooBaseAnother):
+    def __init__(self):
+        super().__init__()
+        self.foo = "bar_multiple_bases"

--- a/test/unit/test_container.py
+++ b/test/unit/test_container.py
@@ -353,6 +353,21 @@ class TestContainer(unittest.IsolatedAsyncioTestCase):
         self.container.register(FooBarChild, qualifier="child")
         inner()
 
+    def test_services_from_multiple_bases_are_injected(self):
+        @self.container.autowire
+        def inner(sub: FooBase):
+            self.assertEqual(sub.foo, "bar_multiple_bases")
+
+        @self.container.autowire
+        def inner_another(sub: FooBaseAnother):
+            self.assertEqual(sub.foo, "bar_multiple_bases")
+
+        self.container.abstract(FooBase)
+        self.container.abstract(FooBaseAnother)
+        self.container.register(FooBarMultipleBases)
+        inner()
+        inner_another()
+
     def test_register_with_qualifier_fails_when_invoked_without(self):
         @self.container.register(qualifier=__name__)
         class RegisterWithQualifierClass: ...

--- a/test/unit/test_container.py
+++ b/test/unit/test_container.py
@@ -342,6 +342,17 @@ class TestContainer(unittest.IsolatedAsyncioTestCase):
             str(context.exception),
         )
 
+    def test_inherited_services_from_same_base_are_injected(self):
+        @self.container.autowire
+        def inner(parent: FooBase = Inject(qualifier="parent"), child: FooBase = Inject(qualifier="child")):
+            self.assertEqual(parent.foo, "bar")
+            self.assertEqual(child.foo, "bar_child")
+
+        self.container.abstract(FooBase)
+        self.container.register(FooBar, qualifier="parent")
+        self.container.register(FooBarChild, qualifier="child")
+        inner()
+
     def test_register_with_qualifier_fails_when_invoked_without(self):
         @self.container.register(qualifier=__name__)
         class RegisterWithQualifierClass: ...

--- a/test/unit/test_container.py
+++ b/test/unit/test_container.py
@@ -353,6 +353,12 @@ class TestContainer(unittest.IsolatedAsyncioTestCase):
         self.container.register(FooBarChild, qualifier="child")
         inner()
 
+        parent = self.container.get(FooBase, qualifier="parent")
+        self.assertEqual(parent.foo, "bar")
+
+        child = self.container.get(FooBase, qualifier="child")
+        self.assertEqual(child.foo, "bar_child")
+
     def test_services_from_multiple_bases_are_injected(self):
         @self.container.autowire
         def inner(sub: FooBase):
@@ -367,6 +373,12 @@ class TestContainer(unittest.IsolatedAsyncioTestCase):
         self.container.register(FooBarMultipleBases)
         inner()
         inner_another()
+
+        foo = self.container.get(FooBase)
+        self.assertEqual(foo.foo, "bar_multiple_bases")
+
+        foo_another = self.container.get(FooBaseAnother)
+        self.assertEqual(foo_another.foo, "bar_multiple_bases")
 
     def test_register_with_qualifier_fails_when_invoked_without(self):
         @self.container.register(qualifier=__name__)

--- a/test/unit/test_container.py
+++ b/test/unit/test_container.py
@@ -19,7 +19,7 @@ from wireup.ioc.dependency_container import DependencyContainer
 from wireup.ioc.parameter import ParameterBag, TemplatedString
 from wireup.ioc.types import AnnotatedParameter, ParameterWrapper
 
-from test.fixtures import Counter, FooBar, FooBase, FooBaz
+from test.fixtures import Counter, FooBar, FooBase, FooBaz, FooBaseAnother, FooBarMultipleBases, FooBarChild
 from test.unit import services
 from test.unit.services.no_annotations.random.random_service import RandomService
 from test.unit.services.no_annotations.random.truly_random_service import TrulyRandomService

--- a/test/unit/test_container.py
+++ b/test/unit/test_container.py
@@ -19,7 +19,7 @@ from wireup.ioc.dependency_container import DependencyContainer
 from wireup.ioc.parameter import ParameterBag, TemplatedString
 from wireup.ioc.types import AnnotatedParameter, ParameterWrapper
 
-from test.fixtures import Counter, FooBar, FooBase, FooBaz, FooBaseAnother, FooBarMultipleBases, FooBarChild
+from test.fixtures import Counter, FooBar, FooBarChild, FooBarMultipleBases, FooBase, FooBaseAnother, FooBaz
 from test.unit import services
 from test.unit.services.no_annotations.random.random_service import RandomService
 from test.unit.services.no_annotations.random.truly_random_service import TrulyRandomService

--- a/test/unit/test_service_registry_dependency_graph.py
+++ b/test/unit/test_service_registry_dependency_graph.py
@@ -77,35 +77,6 @@ class TestServiceRegistry(unittest.TestCase):
             {ImplementationA: set(), ImplementationB: set(), ServiceWithInterface: {ImplementationA, ImplementationB}},
         )
 
-    def test_dependency_graph_with_deep_interface(self):
-        class MyInterface:
-            pass
-
-        class ImplementationParent(MyInterface):
-            pass
-
-        class ImplementationChild(ImplementationParent):
-            pass
-
-        class ServiceWithInterface:
-            def __init__(self, iface: MyInterface):
-                self.iface = iface
-
-        self.registry.register_abstract(MyInterface)
-        self.registry.register_service(ImplementationParent, qualifier="parent", lifetime=ServiceLifetime.SINGLETON)
-        self.registry.register_service(ImplementationChild, qualifier="child", lifetime=ServiceLifetime.SINGLETON)
-        self.registry.register_service(ServiceWithInterface, qualifier=None, lifetime=ServiceLifetime.SINGLETON)
-
-        graph = self.registry.get_dependency_graph()
-        self.assertEqual(
-            graph,
-            {
-                ImplementationParent: set(),
-                ImplementationChild: set(),
-                ServiceWithInterface: {ImplementationParent, ImplementationChild}
-            },
-        )
-
     def test_dependency_graph_with_transient_interfaces(self):
         class MyInterface:
             pass

--- a/test/unit/test_service_registry_dependency_graph.py
+++ b/test/unit/test_service_registry_dependency_graph.py
@@ -102,7 +102,7 @@ class TestServiceRegistry(unittest.TestCase):
             {
                 ImplementationParent: set(),
                 ImplementationChild: set(),
-                ServiceWithInterface: {ImplementationParent, ImplementationChild}
+                ServiceWithInterface: {ImplementationParent, ImplementationChild},
             },
         )
 

--- a/test/unit/test_service_registry_dependency_graph.py
+++ b/test/unit/test_service_registry_dependency_graph.py
@@ -102,7 +102,7 @@ class TestServiceRegistry(unittest.TestCase):
             {
                 ImplementationParent: set(),
                 ImplementationChild: set(),
-                ServiceWithInterface: {ImplementationParent, ImplementationChild},
+                ServiceWithInterface: {ImplementationParent, ImplementationChild}
             },
         )
 

--- a/test/unit/test_service_registry_dependency_graph.py
+++ b/test/unit/test_service_registry_dependency_graph.py
@@ -77,6 +77,35 @@ class TestServiceRegistry(unittest.TestCase):
             {ImplementationA: set(), ImplementationB: set(), ServiceWithInterface: {ImplementationA, ImplementationB}},
         )
 
+    def test_dependency_graph_with_deep_interface(self):
+        class MyInterface:
+            pass
+
+        class ImplementationParent(MyInterface):
+            pass
+
+        class ImplementationChild(ImplementationParent):
+            pass
+
+        class ServiceWithInterface:
+            def __init__(self, iface: MyInterface):
+                self.iface = iface
+
+        self.registry.register_abstract(MyInterface)
+        self.registry.register_service(ImplementationParent, qualifier="parent", lifetime=ServiceLifetime.SINGLETON)
+        self.registry.register_service(ImplementationChild, qualifier="child", lifetime=ServiceLifetime.SINGLETON)
+        self.registry.register_service(ServiceWithInterface, qualifier=None, lifetime=ServiceLifetime.SINGLETON)
+
+        graph = self.registry.get_dependency_graph()
+        self.assertEqual(
+            graph,
+            {
+                ImplementationParent: set(),
+                ImplementationChild: set(),
+                ServiceWithInterface: {ImplementationParent, ImplementationChild}
+            },
+        )
+
     def test_dependency_graph_with_transient_interfaces(self):
         class MyInterface:
             pass

--- a/wireup/ioc/service_registry.py
+++ b/wireup/ioc/service_registry.py
@@ -86,7 +86,7 @@ class ServiceRegistry:
         if self.is_type_with_qualifier_known(klass, qualifier):
             raise DuplicateServiceRegistrationError(klass, qualifier)
 
-        def discover_interfaces(bases=klass.__bases__):
+        def discover_interfaces(bases: tuple[type, ...] = klass.__bases__) -> None:
             for base in bases:
                 if base and self.is_interface_known(base):
                     if qualifier in self.known_interfaces[base]:

--- a/wireup/ioc/service_registry.py
+++ b/wireup/ioc/service_registry.py
@@ -86,15 +86,15 @@ class ServiceRegistry:
         if self.is_type_with_qualifier_known(klass, qualifier):
             raise DuplicateServiceRegistrationError(klass, qualifier)
 
-        base = klass.__base__
-        while base:
-            if base and self.is_interface_known(base):
-                if qualifier in self.known_interfaces[base]:
-                    raise DuplicateQualifierForInterfaceError(klass, qualifier)
+        def discover_interfaces(bases=klass.__bases__):
+            for base in bases:
+                if base and self.is_interface_known(base):
+                    if qualifier in self.known_interfaces[base]:
+                        raise DuplicateQualifierForInterfaceError(klass, qualifier)
 
-                self.known_interfaces[base][qualifier] = klass
-                break
-            base = base.__base__
+                    self.known_interfaces[base][qualifier] = klass
+                discover_interfaces(base.__bases__)
+        discover_interfaces()
 
         self.known_impls[klass].add(qualifier)
         self.target_init_context(klass, lifetime)

--- a/wireup/ioc/service_registry.py
+++ b/wireup/ioc/service_registry.py
@@ -86,11 +86,15 @@ class ServiceRegistry:
         if self.is_type_with_qualifier_known(klass, qualifier):
             raise DuplicateServiceRegistrationError(klass, qualifier)
 
-        if klass.__base__ and self.is_interface_known(klass.__base__):
-            if qualifier in self.known_interfaces[klass.__base__]:
-                raise DuplicateQualifierForInterfaceError(klass, qualifier)
+        base = klass.__base__
+        while base:
+            if base and self.is_interface_known(base):
+                if qualifier in self.known_interfaces[base]:
+                    raise DuplicateQualifierForInterfaceError(klass, qualifier)
 
-            self.known_interfaces[klass.__base__][qualifier] = klass
+                self.known_interfaces[base][qualifier] = klass
+                break
+            base = base.__base__
 
         self.known_impls[klass].add(qualifier)
         self.target_init_context(klass, lifetime)

--- a/wireup/ioc/service_registry.py
+++ b/wireup/ioc/service_registry.py
@@ -86,7 +86,7 @@ class ServiceRegistry:
         if self.is_type_with_qualifier_known(klass, qualifier):
             raise DuplicateServiceRegistrationError(klass, qualifier)
 
-        def discover_interfaces(bases: tuple[type, ...] = klass.__bases__) -> None:
+        def discover_interfaces(bases: tuple[type, ...]) -> None:
             for base in bases:
                 if base and self.is_interface_known(base):
                     if qualifier in self.known_interfaces[base]:
@@ -94,7 +94,8 @@ class ServiceRegistry:
 
                     self.known_interfaces[base][qualifier] = klass
                 discover_interfaces(base.__bases__)
-        discover_interfaces()
+
+        discover_interfaces(klass.__bases__)
 
         self.known_impls[klass].add(qualifier)
         self.target_init_context(klass, lifetime)


### PR DESCRIPTION
This has a lot of applications where multiple inheritence is used.

Example:
```
@abstract
class A(ABC):
...

@service(qualifier="b")
@service
class B(A):
...

@service(qualifier="c")
class C(B):
...
```
Now both services B and C can be injected using a qualifier and using the interface A.

Another example is when inheriting from multiple interfaces:

```
@abstract
class A(ABC):
...

@abstract
class B(ABC):
...

@service
class C(A, B):
...
```

Service C can now be injected using both A and B, since it implements both.

This addresses https://github.com/maldoinc/wireup/issues/48