### PR TITLE
Do not try to validate lifetime of abstract dependencies

### DIFF
--- a/wireup/ioc/validation.py
+++ b/wireup/ioc/validation.py
@@ -47,6 +47,7 @@ def assert_lifetime_valid(
 ) -> None:
     if (
         not dependency.is_parameter
+        and not container._registry.is_interface_known(dependency.klass)
         and container._registry.lifetime[impl] == "singleton"
         and (dep_lifetime := container._registry.lifetime[dependency.klass]) != "singleton"
     ):


### PR DESCRIPTION
I noticed a bug while trying to upgrade to v1. As far as I can tell, this happens when there is a service which has a dependency on an interface. The validation logic for checking compatible lifetimes seems to not check if a dependency is and abstract or not. And since abstracts do not have a lifetime, it raises a KeyError


```
@abstract
class InterfaceA(ABC):
...

@dataclass
@service
class ServiceB:
    dep: InterfaceA
...
```
produces KeyError