### PR TITLE
Skip validations if the type of dependency is a built in type

### DIFF
--- a/wireup/ioc/validation.py
+++ b/wireup/ioc/validation.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import builtins
 import inspect
 import typing
 from typing import Any
@@ -38,8 +39,9 @@ def assert_dependencies_valid(container: BaseContainer) -> None:
     """Assert that all required dependencies exist for this container instance."""
     for (impl, _), service_factory in container._registry.factories.items():
         for name, dependency in container._registry.dependencies[service_factory.factory].items():
-            assert_dependency_exists(container=container, parameter=dependency, target=impl, name=name)
-            assert_lifetime_valid(container, impl, name, dependency, service_factory.factory)
+            if dependency.klass.__name__ not in dir(builtins):
+                assert_dependency_exists(container=container, parameter=dependency, target=impl, name=name)
+                assert_lifetime_valid(container, impl, name, dependency, service_factory.factory)
 
 
 def assert_lifetime_valid(


### PR DESCRIPTION
Have a service like this which is causing an issue:

```
@service
@dataclass
class serviceB:
    dependencyA: ServiceA
    value: int = 100
```
Causes:

WireupError: Parameter '...' of Type ... depends on an unknown service Type builtins.int with qualifier None.

I am not 100% sure about the solution and open to suggestions. But the scope of validation should be limited I think.