### PR TITLE
Enable dot notation in parameter expressions

### DIFF
--- a/test/unit/test_parameter.py
+++ b/test/unit/test_parameter.py
@@ -129,7 +129,7 @@ def test_get_templated_string_with_broken_paths():
         ValueError,
         match=re.escape(
             "Provided config key format is invalid: 'param1..property1'."
-            " Please provide a non-empty config-key, or a vaild `dot` separated path, with non-empty parts."
+            " Please provide a non-empty config key, or a valid dot-separated path, with non-empty parts."
         ),
     ):
         bag.get(templated_string)
@@ -139,7 +139,7 @@ def test_get_templated_string_with_broken_paths():
         ValueError,
         match=re.escape(
             "Provided config key format is invalid: 'param1.'."
-            " Please provide a non-empty config-key, or a vaild `dot` separated path, with non-empty parts."
+            " Please provide a non-empty config key, or a valid dot-separated path, with non-empty parts."
         ),
     ):
         bag.get(templated_string)
@@ -149,7 +149,7 @@ def test_get_templated_string_with_broken_paths():
         ValueError,
         match=re.escape(
             "Provided config key format is invalid: '.param1'."
-            " Please provide a non-empty config-key, or a vaild `dot` separated path, with non-empty parts."
+            " Please provide a non-empty config key, or a valid dot-separated path, with non-empty parts."
         ),
     ):
         bag.get(templated_string)
@@ -159,7 +159,7 @@ def test_get_templated_string_with_broken_paths():
         ValueError,
         match=re.escape(
             "Provided config key format is invalid: '.param1.'."
-            " Please provide a non-empty config-key, or a vaild `dot` separated path, with non-empty parts."
+            " Please provide a non-empty config key, or a valid dot-separated path, with non-empty parts."
         ),
     ):
         bag.get(templated_string)

--- a/wireup/errors.py
+++ b/wireup/errors.py
@@ -48,7 +48,6 @@ class UnknownParameterError(WireupError):
             message = f"Unknown config key requested: '{parameter_name}'"
 
         super().__init__(message)
-        super().__init__(f"Unknown config key requested: {parameter_name}")
 
 
 class FactoryReturnTypeIsEmptyError(WireupError):


### PR DESCRIPTION
to resolve #44 

please ignore committed tests and dependencies, they were added to showcase:
- support of dot notation
- support of dicts and objects traversal

tests will be fixed once solution approach is validated.