### PR TITLE
Allow Injections of FastApi's WebSocket Object

### DIFF
--- a/docs/pages/integrations/fastapi.md
+++ b/docs/pages/integrations/fastapi.md
@@ -70,10 +70,10 @@ See [Annotations](../annotations.md) for more details.
     The WireupRoute class optimizes this by making Wireup-specific parameters only visible to Wireup, 
     removing unnecessary processing by FastAPI's dependency injection system.
 
-### Inject FastAPI request
+### Inject FastAPI request or websocket
 
-A key feature of the integration is to expose `fastapi.Request` in Wireup.
-To allow injecting it in your services you must add `wireup.integration.fastapi` module to your service modules
+A key feature of the integration is to expose `fastapi.Request` and `fastapi.WebSocket`in Wireup.
+To allow injecting these in your services you must add `wireup.integration.fastapi` module to your service modules
 when creating a container.
 
 Services depending on it should be transient or scoped, so that these are not shared across requests.
@@ -86,6 +86,15 @@ class HttpAuthenticationService:
 
 @service(lifetime="scoped")
 def example_factory(request: fastapi.Request) -> ExampleService: ...
+
+
+@service(lifetime="scoped")
+class ChatService:
+    def __init__(self, websocket: fastapi.WebSocket) -> None: ...
+        await self.websocket.accept()
+
+    async def send(self, data: str):
+        await self.websocket.send_text(data)
 ```
 
 ### Accessing the Container

--- a/docs/pages/integrations/fastapi.md
+++ b/docs/pages/integrations/fastapi.md
@@ -90,7 +90,7 @@ def example_factory(request: fastapi.Request) -> ExampleService: ...
 
 @service(lifetime="scoped")
 class ChatService:
-    def __init__(self, websocket: fastapi.WebSocket) -> None: ...
+    def __init__(self, websocket: fastapi.WebSocket) -> None:
         await self.websocket.accept()
 
     async def send(self, data: str):

--- a/test/integration/fastapi/router.py
+++ b/test/integration/fastapi/router.py
@@ -4,7 +4,7 @@ from fastapi import APIRouter, Depends, Request, WebSocket
 from typing_extensions import Annotated
 from wireup import Inject, Injected
 
-from test.integration.fastapi.services import ServiceUsingFastapiRequest
+from test.integration.fastapi.services import ServiceUsingFastapiRequest, WebsocketInjectedGreeterService
 from test.shared.shared_services.greeter import GreeterService
 from test.shared.shared_services.rand import RandomService
 from test.shared.shared_services.scoped import ScopedService, ScopedServiceDependency
@@ -60,6 +60,13 @@ async def websocket_endpoint(
     data = await websocket.receive_text()
     await websocket.send_text(greeter.greet(data))
     await websocket.close()
+
+
+@router.websocket("/ws_in_service")
+async def injected_websocket_endpoint(
+    greeter: Injected[WebsocketInjectedGreeterService],
+):
+    await greeter.greet()
 
 
 @router.get("/scoped")

--- a/test/integration/fastapi/router.py
+++ b/test/integration/fastapi/router.py
@@ -63,9 +63,7 @@ async def websocket_endpoint(
 
 
 @router.websocket("/ws_in_service")
-async def injected_websocket_endpoint(
-    greeter: Injected[WebsocketInjectedGreeterService],
-):
+async def injected_websocket_endpoint(greeter: Injected[WebsocketInjectedGreeterService]):
     await greeter.greet()
 
 

--- a/test/integration/fastapi/services.py
+++ b/test/integration/fastapi/services.py
@@ -20,3 +20,9 @@ class WebsocketInjectedGreeterService:
         data = await self.websocket.receive_text()
         await self.websocket.send_text(f"Hello {data}")
         await self.websocket.close()
+
+
+@service(lifetime="scoped")
+@dataclass
+class ScopedWebsocketService:
+    other: WebSocket

--- a/test/integration/fastapi/services.py
+++ b/test/integration/fastapi/services.py
@@ -1,6 +1,6 @@
 from dataclasses import dataclass
 
-from fastapi import Request
+from fastapi import Request, WebSocket
 from wireup import service
 
 
@@ -8,3 +8,15 @@ from wireup import service
 @dataclass
 class ServiceUsingFastapiRequest:
     req: Request
+
+
+@dataclass
+@service(lifetime="scoped")
+class WebsocketInjectedGreeterService:
+    websocket: WebSocket
+
+    async def greet(self):
+        await self.websocket.accept()
+        data = await self.websocket.receive_text()
+        await self.websocket.send_text(f"Hello {data}")
+        await self.websocket.close()

--- a/test/integration/fastapi/test_fastapi_integration.py
+++ b/test/integration/fastapi/test_fastapi_integration.py
@@ -74,7 +74,7 @@ def test_injects_parameters(client: TestClient):
     assert response.json() == {"foo": "bar", "foo_foo": "bar-bar"}
 
 
-@pytest.mark.parametrize("endpoint", ["/ws", "/ws/wireup_injected"])
+@pytest.mark.parametrize("endpoint", ["/ws", "/ws/wireup_injected", "/ws_in_service"])
 def test_websocket(client: TestClient, endpoint: str):
     with client.websocket_connect(endpoint) as websocket:
         websocket.send_text("World")

--- a/test/integration/fastapi/wireup_route.py
+++ b/test/integration/fastapi/wireup_route.py
@@ -2,8 +2,9 @@ from fastapi import APIRouter, WebSocket
 from wireup import Injected
 from wireup.integration.fastapi import WireupRoute
 
+from test.integration.fastapi.services import ScopedWebsocketService
 from test.shared.shared_services.greeter import GreeterService
-from test.shared.shared_services.scoped import ScopedService, ScopedServiceDependency, ScopedWebsocketService
+from test.shared.shared_services.scoped import ScopedService, ScopedServiceDependency
 
 router = APIRouter(route_class=WireupRoute)
 

--- a/test/integration/fastapi/wireup_route.py
+++ b/test/integration/fastapi/wireup_route.py
@@ -3,7 +3,7 @@ from wireup import Injected
 from wireup.integration.fastapi import WireupRoute
 
 from test.shared.shared_services.greeter import GreeterService
-from test.shared.shared_services.scoped import ScopedService, ScopedServiceDependency
+from test.shared.shared_services.scoped import ScopedService, ScopedServiceDependency, ScopedWebsocketService
 
 router = APIRouter(route_class=WireupRoute)
 
@@ -29,9 +29,11 @@ async def websocket_endpoint_wireup_injected(
     scoped_service: Injected[ScopedService],
     scoped_service2: Injected[ScopedService],
     scoped_service_dependency: Injected[ScopedServiceDependency],
+    scoped_websocket_service: Injected[ScopedWebsocketService],
 ):
     assert scoped_service is scoped_service2
     assert scoped_service.other is scoped_service_dependency
+    assert scoped_websocket_service.other is websocket
 
     await websocket.accept()
     data = await websocket.receive_text()

--- a/test/shared/shared_services/scoped.py
+++ b/test/shared/shared_services/scoped.py
@@ -1,6 +1,5 @@
 from dataclasses import dataclass
 
-from fastapi import WebSocket
 from wireup import service
 
 
@@ -12,9 +11,3 @@ class ScopedServiceDependency: ...
 @dataclass
 class ScopedService:
     other: ScopedServiceDependency
-
-
-@service(lifetime="scoped")
-@dataclass
-class ScopedWebsocketService:
-    other: WebSocket

--- a/test/shared/shared_services/scoped.py
+++ b/test/shared/shared_services/scoped.py
@@ -1,5 +1,5 @@
 from dataclasses import dataclass
-
+from fastapi import WebSocket
 from wireup import service
 
 
@@ -11,3 +11,9 @@ class ScopedServiceDependency: ...
 @dataclass
 class ScopedService:
     other: ScopedServiceDependency
+
+
+@service(lifetime="scoped")
+@dataclass
+class ScopedWebsocketService:
+    other: WebSocket

--- a/test/shared/shared_services/scoped.py
+++ b/test/shared/shared_services/scoped.py
@@ -1,4 +1,5 @@
 from dataclasses import dataclass
+
 from fastapi import WebSocket
 from wireup import service
 

--- a/wireup/integration/fastapi.py
+++ b/wireup/integration/fastapi.py
@@ -55,10 +55,11 @@ def fastapi_request_factory() -> Request:
     """
     try:
         connection = current_request.get()
-        if not isinstance(connection, Request):
-            msg = "Not a Request instance"
-            raise WireupError(msg)
-        return connection
+        if isinstance(connection, Request):
+            return connection
+
+        msg = "Not a Request instance"
+        raise WireupError(msg)
     except LookupError as e:
         msg = "fastapi.Request in wireup is only available during a request."
         raise WireupError(msg) from e
@@ -72,10 +73,12 @@ def fastapi_websocket_factory() -> WebSocket:
     """
     try:
         connection = current_websocket.get()
-        if not isinstance(connection, WebSocket):
-            msg = "Not a WebSocket instance"
-            raise WireupError(msg)
-        return connection
+        if isinstance(connection, WebSocket):
+            return connection
+
+        msg = "Not a WebSocket instance"
+        raise WireupError(msg)
+
     except LookupError as e:
         msg = "fastapi.WebSocket in wireup is only available during a websocket connection."
         raise WireupError(msg) from e
@@ -92,7 +95,8 @@ def _inject_websocket_route(
         async with container.enter_scope() as scoped_container:
             token = current_ws_container.set(scoped_container)
             if not websocket_param_name or websocket_param_name not in kwargs:
-                raise WireupError("Unable to determine websocket parameter")
+                msg = "Unable to determine websocket parameter"
+                raise WireupError(msg)
 
             token_websocket = current_websocket.set(kwargs[websocket_param_name])
             kwargs = {key: value for key, value in kwargs.items() if key != fallback_websocket_param}

--- a/wireup/integration/fastapi.py
+++ b/wireup/integration/fastapi.py
@@ -1,11 +1,7 @@
 import contextlib
 import functools
 from contextvars import ContextVar
-from typing import (
-    Any,
-    AsyncIterator,
-    Callable,
-)
+from typing import Any, AsyncIterator, Callable, Union
 
 from fastapi import FastAPI, Request, WebSocket
 from fastapi.routing import APIRoute, APIWebSocketRoute
@@ -18,7 +14,7 @@ from wireup.ioc.container.async_container import AsyncContainer, ScopedAsyncCont
 from wireup.ioc.types import ParameterWrapper
 from wireup.ioc.validation import get_valid_injection_annotated_parameters, hide_annotated_names
 
-current_request_socket: ContextVar[Request | WebSocket] = ContextVar("wireup_fastapi_request")
+current_request_socket: ContextVar[Union[Request, WebSocket]] = ContextVar("wireup_fastapi_request")
 current_ws_container: ContextVar[ScopedAsyncContainer] = ContextVar("wireup_fastapi_container")
 
 
@@ -59,7 +55,8 @@ def fastapi_request_factory() -> Request:
     try:
         c = current_request_socket.get()
         if not isinstance(c, Request):
-            raise LookupError("Not a Request instance")
+            msg = "Not a Request instance"
+            raise WireupError(msg)
         return c
     except LookupError as e:
         msg = "fastapi.Request in wireup is only available during a request."
@@ -75,7 +72,8 @@ def fastapi_websocket_factory() -> WebSocket:
     try:
         c = current_request_socket.get()
         if not isinstance(c, WebSocket):
-            raise LookupError("Not a WebSocket instance")
+            msg = "Not a WebSocket instance"
+            raise WireupError(msg)
         return c
     except LookupError as e:
         msg = "fastapi.WebSocket in wireup is only available during a websocket connection."

--- a/wireup/integration/fastapi.py
+++ b/wireup/integration/fastapi.py
@@ -167,6 +167,6 @@ def get_app_container(app: FastAPI) -> AsyncContainer:
 def get_request_container() -> ScopedAsyncContainer:
     """When inside a request, returns the scoped container instance handling the current request."""
     try:
-        return current_request.get().state.wireup_container
+        return current_request_socket.get().state.wireup_container
     except LookupError:
         return current_ws_container.get()

--- a/wireup/integration/fastapi.py
+++ b/wireup/integration/fastapi.py
@@ -82,7 +82,6 @@ def fastapi_websocket_factory() -> WebSocket:
         raise WireupError(msg) from e
 
 
-
 # We need to inject websocket routes separately as the regular fastapi middlewares work only for http.
 def _inject_websocket_route(container: AsyncContainer, target: Callable[..., Any]) -> Callable[..., Any]:
     names_to_inject = get_valid_injection_annotated_parameters(container, target)

--- a/wireup/integration/fastapi.py
+++ b/wireup/integration/fastapi.py
@@ -21,8 +21,7 @@ from wireup.ioc.container.async_container import AsyncContainer, ScopedAsyncCont
 from wireup.ioc.types import ParameterWrapper
 from wireup.ioc.validation import get_valid_injection_annotated_parameters, hide_annotated_names
 
-current_request: ContextVar[Request] = ContextVar("wireup_fastapi_request")
-current_socket: ContextVar[WebSocket] = ContextVar("wireup_fastapi_socket")
+current_request_socket: ContextVar[Request | WebSocket] = ContextVar("wireup_fastapi_request")
 current_ws_container: ContextVar[ScopedAsyncContainer] = ContextVar("wireup_fastapi_container")
 
 

--- a/wireup/integration/fastapi.py
+++ b/wireup/integration/fastapi.py
@@ -60,7 +60,10 @@ def fastapi_request_factory() -> Request:
     Note that this requires the Wireup-FastAPI integration to be set up.
     """
     try:
-        return current_request.get()
+        c = current_request_socket.get()
+        if not isinstance(c, Request):
+            raise LookupError("Not a Request instance")
+        return c
     except LookupError as e:
         msg = "fastapi.Request in wireup is only available during a request."
         raise WireupError(msg) from e

--- a/wireup/integration/fastapi.py
+++ b/wireup/integration/fastapi.py
@@ -74,6 +74,20 @@ def fastapi_request_factory() -> Request:
         raise WireupError(msg) from e
 
 
+@service(lifetime="scoped")
+def fastapi_socket_factory() -> WebSocket:
+    """Provide the current FastAPI request as a dependency.
+
+    Note that this requires the Wireup-FastAPI integration to be set up.
+    """
+    try:
+        return current_socket.get()
+    except LookupError as e:
+        msg = "WEbsocket error"
+        raise WireupError(msg) from e
+
+
+
 # We need to inject websocket routes separately as the regular fastapi middlewares work only for http.
 def _inject_websocket_route(container: AsyncContainer, target: Callable[..., Any]) -> Callable[..., Any]:
     names_to_inject = get_valid_injection_annotated_parameters(container, target)

--- a/wireup/integration/fastapi.py
+++ b/wireup/integration/fastapi.py
@@ -18,6 +18,7 @@ current_request: ContextVar[Request] = ContextVar("wireup_fastapi_request")
 current_websocket: ContextVar[WebSocket] = ContextVar("wireup_fastapi_websocket")
 current_ws_container: ContextVar[ScopedAsyncContainer] = ContextVar("wireup_fastapi_container")
 
+fallback_websocket_param = "_wireup_websocket"
 
 class WireupRoute(APIRoute):
     def __init__(self, path: str, endpoint: Callable[..., Any], **kwargs: Any) -> None:
@@ -123,7 +124,7 @@ def _inject_routes(container: AsyncContainer, app: FastAPI) -> None:
             and is_callable_using_wireup_dependencies(route.dependant.call)
         ):
             if isinstance(route, APIWebSocketRoute) and route.dependant.websocket_param_name is None:
-                route.dependant.websocket_param_name = "_wireup_websocket"
+                route.dependant.websocket_param_name = fallback_websocket_param
 
             target = route.dependant.call
             route.dependant.call = (

--- a/wireup/integration/fastapi.py
+++ b/wireup/integration/fastapi.py
@@ -83,10 +83,6 @@ def _inject_websocket_route(
     async def _inner(*args: Any, **kwargs: Any) -> Any:
         async with container.enter_scope() as scoped_container:
             token = current_ws_container.set(scoped_container)
-            if not websocket_param_name or websocket_param_name not in kwargs:
-                msg = "Unable to determine websocket parameter"
-                raise WireupError(msg)
-
             token_websocket = current_websocket.set(kwargs[websocket_param_name])
             kwargs = {key: value for key, value in kwargs.items() if key != _fallback_websocket_param}
 

--- a/wireup/integration/fastapi.py
+++ b/wireup/integration/fastapi.py
@@ -14,7 +14,7 @@ from wireup.ioc.container.async_container import AsyncContainer, ScopedAsyncCont
 from wireup.ioc.types import ParameterWrapper
 from wireup.ioc.validation import get_valid_injection_annotated_parameters, hide_annotated_names
 
-current_connection: ContextVar[Union[Request, WebSocket]] = ContextVar("wireup_fastapi_request")
+current_request: ContextVar[Request] = ContextVar("wireup_fastapi_request")
 current_ws_container: ContextVar[ScopedAsyncContainer] = ContextVar("wireup_fastapi_container")
 
 
@@ -36,14 +36,14 @@ class WireupMiddleware:
         else:
             return await self.app(scope, receive, send)
 
-        token = current_connection.set(connection)
+        token = current_request.set(connection)
 
         try:
             async with connection.app.state.wireup_container.enter_scope() as scoped_container:
                 connection.state.wireup_container = scoped_container
                 return await self.app(scope, receive, send)
         finally:
-            current_connection.reset(token)
+            current_request.reset(token)
 
 
 @service(lifetime="scoped")
@@ -53,7 +53,7 @@ def fastapi_request_factory() -> Request:
     Note that this requires the Wireup-FastAPI integration to be set up.
     """
     try:
-        connection = current_connection.get()
+        connection = current_request.get()
         if not isinstance(connection, Request):
             msg = "Not a Request instance"
             raise WireupError(msg)
@@ -173,6 +173,6 @@ def get_app_container(app: FastAPI) -> AsyncContainer:
 def get_request_container() -> ScopedAsyncContainer:
     """When inside a request, returns the scoped container instance handling the current request."""
     try:
-        return current_connection.get().state.wireup_container
+        return current_request.get().state.wireup_container
     except LookupError:
         return current_ws_container.get()

--- a/wireup/integration/fastapi.py
+++ b/wireup/integration/fastapi.py
@@ -69,7 +69,7 @@ def fastapi_websocket_factory() -> WebSocket:
     Note that this requires the Wireup-FastAPI integration to be set up.
     """
     try:
-        connection = current_connection.get()
+        connection = current_websocket.get()
         if not isinstance(connection, WebSocket):
             msg = "Not a WebSocket instance"
             raise WireupError(msg)

--- a/wireup/integration/fastapi.py
+++ b/wireup/integration/fastapi.py
@@ -1,7 +1,7 @@
 import contextlib
 import functools
 from contextvars import ContextVar
-from typing import Any, AsyncIterator, Callable, Union
+from typing import Any, AsyncIterator, Callable
 
 from fastapi import FastAPI, Request, WebSocket
 from fastapi.routing import APIRoute, APIWebSocketRoute
@@ -75,7 +75,7 @@ def fastapi_websocket_factory() -> WebSocket:
 
 # We need to inject websocket routes separately as the regular fastapi middlewares work only for http.
 def _inject_websocket_route(
-    container: AsyncContainer, target: Callable[..., Any], websocket_param_name: Union[str, None]
+    container: AsyncContainer, target: Callable[..., Any], websocket_param_name: str
 ) -> Callable[..., Any]:
     names_to_inject = get_valid_injection_annotated_parameters(container, target)
 

--- a/wireup/integration/fastapi.py
+++ b/wireup/integration/fastapi.py
@@ -18,7 +18,7 @@ current_request: ContextVar[Request] = ContextVar("wireup_fastapi_request")
 current_websocket: ContextVar[WebSocket] = ContextVar("wireup_fastapi_websocket")
 current_ws_container: ContextVar[ScopedAsyncContainer] = ContextVar("wireup_fastapi_container")
 
-fallback_websocket_param = "_wireup_websocket"
+_fallback_websocket_param = "_wireup_websocket"
 
 
 class WireupRoute(APIRoute):
@@ -88,7 +88,7 @@ def _inject_websocket_route(
                 raise WireupError(msg)
 
             token_websocket = current_websocket.set(kwargs[websocket_param_name])
-            kwargs = {key: value for key, value in kwargs.items() if key != fallback_websocket_param}
+            kwargs = {key: value for key, value in kwargs.items() if key != _fallback_websocket_param}
 
             injected_names = {
                 name: container.params.get(param.annotation.param)
@@ -117,7 +117,7 @@ def _inject_routes(container: AsyncContainer, app: FastAPI) -> None:
             and is_callable_using_wireup_dependencies(route.dependant.call)
         ):
             if isinstance(route, APIWebSocketRoute) and route.dependant.websocket_param_name is None:
-                route.dependant.websocket_param_name = fallback_websocket_param
+                route.dependant.websocket_param_name = _fallback_websocket_param
 
             target = route.dependant.call
             route.dependant.call = (

--- a/wireup/integration/fastapi.py
+++ b/wireup/integration/fastapi.py
@@ -22,6 +22,7 @@ from wireup.ioc.types import ParameterWrapper
 from wireup.ioc.validation import get_valid_injection_annotated_parameters, hide_annotated_names
 
 current_request: ContextVar[Request] = ContextVar("wireup_fastapi_request")
+current_socket: ContextVar[WebSocket] = ContextVar("wireup_fastapi_socket")
 current_ws_container: ContextVar[ScopedAsyncContainer] = ContextVar("wireup_fastapi_container")
 
 

--- a/wireup/integration/fastapi.py
+++ b/wireup/integration/fastapi.py
@@ -15,6 +15,7 @@ from wireup.ioc.types import ParameterWrapper
 from wireup.ioc.validation import get_valid_injection_annotated_parameters, hide_annotated_names
 
 current_request: ContextVar[Request] = ContextVar("wireup_fastapi_request")
+current_websocket: ContextVar[WebSocket] = ContextVar("wireup_fastapi_websocket")
 current_ws_container: ContextVar[ScopedAsyncContainer] = ContextVar("wireup_fastapi_container")
 
 

--- a/wireup/integration/fastapi.py
+++ b/wireup/integration/fastapi.py
@@ -76,6 +76,7 @@ def _inject_websocket_route(
     @functools.wraps(target)
     async def _inner(*args: Any, **kwargs: Any) -> Any:
         async with container.enter_scope() as scoped_container:
+            kwargs[websocket_param_name].state.wireup_container = scoped_container
             token_websocket = current_websocket.set(kwargs[websocket_param_name])
             kwargs = {key: value for key, value in kwargs.items() if key != _fallback_websocket_param}
 

--- a/wireup/integration/fastapi.py
+++ b/wireup/integration/fastapi.py
@@ -160,6 +160,7 @@ def setup(container: AsyncContainer, app: FastAPI) -> None:
     """
     _update_lifespan(container, app)
     app.add_middleware(BaseHTTPMiddleware, dispatch=_wireup_request_middleware)
+    app.add_middleware(WireupSocketMiddleware)
     _inject_routes(container, app)
     app.state.wireup_container = container
 

--- a/wireup/integration/fastapi.py
+++ b/wireup/integration/fastapi.py
@@ -11,6 +11,8 @@ from typing import (
 from fastapi import FastAPI, Request, Response
 from fastapi.routing import APIRoute, APIWebSocketRoute
 from starlette.middleware.base import BaseHTTPMiddleware
+from starlette.types import ASGIApp, Message, Receive, Scope, Send
+from starlette.websockets import WebSocket
 
 from wireup import inject_from_container, service
 from wireup.errors import WireupError

--- a/wireup/integration/fastapi.py
+++ b/wireup/integration/fastapi.py
@@ -4,15 +4,12 @@ from contextvars import ContextVar
 from typing import (
     Any,
     AsyncIterator,
-    Awaitable,
     Callable,
 )
 
-from fastapi import FastAPI, Request, Response
+from fastapi import FastAPI, Request, WebSocket
 from fastapi.routing import APIRoute, APIWebSocketRoute
-from starlette.middleware.base import BaseHTTPMiddleware
-from starlette.types import ASGIApp, Message, Receive, Scope, Send
-from starlette.websockets import WebSocket
+from starlette.types import ASGIApp, Receive, Scope, Send
 
 from wireup import inject_from_container, service
 from wireup.errors import WireupError

--- a/wireup/integration/fastapi.py
+++ b/wireup/integration/fastapi.py
@@ -157,8 +157,7 @@ def setup(container: AsyncContainer, app: FastAPI) -> None:
     ```
     """
     _update_lifespan(container, app)
-    app.add_middleware(BaseHTTPMiddleware, dispatch=_wireup_request_middleware)
-    app.add_middleware(WireupSocketMiddleware)
+    app.add_middleware(WireupMiddleware)
     _inject_routes(container, app)
     app.state.wireup_container = container
 

--- a/wireup/integration/fastapi.py
+++ b/wireup/integration/fastapi.py
@@ -20,6 +20,7 @@ current_ws_container: ContextVar[ScopedAsyncContainer] = ContextVar("wireup_fast
 
 fallback_websocket_param = "_wireup_websocket"
 
+
 class WireupRoute(APIRoute):
     def __init__(self, path: str, endpoint: Callable[..., Any], **kwargs: Any) -> None:
         hide_annotated_names(endpoint)
@@ -82,9 +83,7 @@ def fastapi_websocket_factory() -> WebSocket:
 
 # We need to inject websocket routes separately as the regular fastapi middlewares work only for http.
 def _inject_websocket_route(
-        container: AsyncContainer,
-        target: Callable[..., Any],
-        websocket_param_name: Union[str, None]
+    container: AsyncContainer, target: Callable[..., Any], websocket_param_name: Union[str, None]
 ) -> Callable[..., Any]:
     names_to_inject = get_valid_injection_annotated_parameters(container, target)
 

--- a/wireup/integration/fastapi.py
+++ b/wireup/integration/fastapi.py
@@ -30,7 +30,7 @@ class WireupMiddleware:
 
     async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
         if scope["type"] == "http":
-            connection = Request(scope)
+            connection = Request(scope, receive, send)
         elif scope["type"] == "websocket":
             connection = WebSocket(scope, receive, send)
         else:

--- a/wireup/integration/fastapi.py
+++ b/wireup/integration/fastapi.py
@@ -32,8 +32,6 @@ class WireupMiddleware:
     async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
         if scope["type"] == "http":
             connection = Request(scope, receive, send)
-        elif scope["type"] == "websocket":
-            connection = WebSocket(scope, receive, send)
         else:
             return await self.app(scope, receive, send)
 

--- a/wireup/integration/fastapi.py
+++ b/wireup/integration/fastapi.py
@@ -54,12 +54,7 @@ def fastapi_request_factory() -> Request:
     Note that this requires the Wireup-FastAPI integration to be set up.
     """
     try:
-        connection = current_request.get()
-        if isinstance(connection, Request):
-            return connection
-
-        msg = "Not a Request instance"
-        raise WireupError(msg)
+        return current_request.get()
     except LookupError as e:
         msg = "fastapi.Request in wireup is only available during a request."
         raise WireupError(msg) from e
@@ -72,13 +67,7 @@ def fastapi_websocket_factory() -> WebSocket:
     Note that this requires the Wireup-FastAPI integration to be set up.
     """
     try:
-        connection = current_websocket.get()
-        if isinstance(connection, WebSocket):
-            return connection
-
-        msg = "Not a WebSocket instance"
-        raise WireupError(msg)
-
+        return current_websocket.get()
     except LookupError as e:
         msg = "fastapi.WebSocket in wireup is only available during a websocket connection."
         raise WireupError(msg) from e

--- a/wireup/integration/fastapi.py
+++ b/wireup/integration/fastapi.py
@@ -119,6 +119,9 @@ def _inject_routes(container: AsyncContainer, app: FastAPI) -> None:
             and route.dependant.call
             and is_callable_using_wireup_dependencies(route.dependant.call)
         ):
+            if isinstance(route, APIWebSocketRoute) and route.dependant.websocket_param_name is None:
+                route.dependant.websocket_param_name = "_wireup_websocket"
+
             target = route.dependant.call
             route.dependant.call = (
                 inject_scoped(target)

--- a/wireup/integration/fastapi.py
+++ b/wireup/integration/fastapi.py
@@ -96,6 +96,7 @@ def _inject_websocket_route(
                 raise WireupError("Unable to determine websocket parameter")
 
             token_websocket = current_websocket.set(kwargs[websocket_param_name])
+            kwargs = {key: value for key, value in kwargs.items() if key != fallback_websocket_param}
 
             injected_names = {
                 name: container.params.get(param.annotation.param)

--- a/wireup/integration/fastapi.py
+++ b/wireup/integration/fastapi.py
@@ -70,15 +70,18 @@ def fastapi_request_factory() -> Request:
 
 
 @service(lifetime="scoped")
-def fastapi_socket_factory() -> WebSocket:
-    """Provide the current FastAPI request as a dependency.
+def fastapi_websocket_factory() -> WebSocket:
+    """Provide the current FastAPI websocket as a dependency.
 
     Note that this requires the Wireup-FastAPI integration to be set up.
     """
     try:
-        return current_socket.get()
+        c = current_request_socket.get()
+        if not isinstance(c, WebSocket):
+            raise LookupError("Not a WebSocket instance")
+        return c
     except LookupError as e:
-        msg = "WEbsocket error"
+        msg = "fastapi.WebSocket in wireup is only available during a websocket connection."
         raise WireupError(msg) from e
 
 


### PR DESCRIPTION
This PR allows FastApi's WebSocket  objects to be injectable as a service anywhere in the code base where normal injection is possible, i.e., beyond FastApi's route endpoints.

This has been possible with Request objects for a while now, and this PR attempts to complete the picture by allowing the same treatment to be applied to WebSockets.

There is a gotcha which I do not find to be a real issue, but it is worth mentioning it here:

If Wireup's WebSocket injections are to be used, FastApi's injections must not be used at the same time. They can't be mixed up together. Example:

If you are doing the following conventional FastApi Injection at router of the websocket and accepting connection:

```
@app.websocket("/endpoint")
async def websocket_endpoint(websocket: WebSocket):
    await websocket.accept()
    ....
```

Then, since the websocket wireup will inject elsewhere will be a different object, your "accept" at the router will not be applied to the wireup's websocket object and any attempt to interact with websocket will raise an exception about connection's state.

A simple solution to work with Wireup's websocket object in routers is as follows:

```
@app.websocket("/endpoint")
async def websocket_endpoint():
    @inject_from_container(container)
    async def accept_socket(websocket: Annotated[WebSocket, Inject()]):
        await websocket.accept()

    await accept_socket()
```

I'm setting this as  a draft PR for the moment to get an initial feedback. Once we are happy with the functionality, can look into adding some tests.

Some questions / doubts:
Do we instantiate Request & WebSocket objects correctly in the middleware?
Are we happy using a single context variable to handle sockets and requests?
Are we happy using a single middleware to handle sockets and requests?
Are we happy using "connection" and "current_connection" variable names?

