### PR TITLE
Raise a warning when redundant annotation is added to services.

### DIFF
--- a/test/unit/services/with_annotations/services.py
+++ b/test/unit/services/with_annotations/services.py
@@ -1,7 +1,7 @@
 import abc
 
 from typing_extensions import Annotated
-from wireup import Inject, abstract, service
+from wireup import Inject, Injected, abstract, service
 
 from test.unit.services.no_annotations.random.random_service import RandomService
 from test.unit.services.no_annotations.random.truly_random_service import TrulyRandomService
@@ -43,6 +43,12 @@ class FooImpl(Foo):
 class OtherFooImpl(Foo):
     def get_foo(self) -> str:
         return "other foo"
+
+
+@service
+class FooImplWithInjected:
+    def __init__(self, foo: Injected[Foo]) -> None:
+        self.foo = foo
 
 
 @service(lifetime="scoped")

--- a/test/unit/test_service_registry.py
+++ b/test/unit/test_service_registry.py
@@ -72,7 +72,7 @@ def test_is_type_with_qualifier_known(registry: ServiceRegistry) -> None:
 
 
 def test_register_with_redundant_annotation(registry: ServiceRegistry) -> None:
-    with pytest.warns(UserWarning, match=r"Injected\[T\] or Annotated\[T, Inject\(\)\] is redundant"):
+    with pytest.warns(UserWarning, match=r"Redundant Injected\[T\] or Annotated\[T, Inject\(\)\] in parameter"):
         registry.register(FooImplWithInjected, lifetime="singleton")
 
 

--- a/test/unit/test_service_registry.py
+++ b/test/unit/test_service_registry.py
@@ -9,6 +9,7 @@ from wireup.errors import (
 from wireup.ioc.service_registry import ServiceRegistry
 
 from test.unit.services.no_annotations.random.random_service import RandomService
+from test.unit.services.with_annotations.services import FooImplWithInjected
 
 
 @pytest.fixture
@@ -68,6 +69,11 @@ def test_is_type_with_qualifier_known(registry: ServiceRegistry) -> None:
 
     registry.register(MyService, qualifier="default", lifetime="singleton")
     assert registry.is_type_with_qualifier_known(MyService, "default")
+
+
+def test_register_with_redundant_annotation(registry: ServiceRegistry) -> None:
+    with pytest.warns(UserWarning, match=r"Injected\[T\] or Annotated\[T, Inject\(\)\] is redundant"):
+        registry.register(FooImplWithInjected, lifetime="singleton")
 
 
 def test_is_interface_known(registry: ServiceRegistry) -> None:

--- a/wireup/ioc/service_registry.py
+++ b/wireup/ioc/service_registry.py
@@ -18,6 +18,7 @@ from wireup.errors import (
 )
 from wireup.ioc.types import AnnotatedParameter, AnyCallable, EmptyContainerInjectionRequest
 from wireup.ioc.util import ensure_is_type, get_globals, param_get_annotation
+from wireup.ioc.validation import stringify_type
 
 if TYPE_CHECKING:
     from wireup.ioc.types import (
@@ -138,7 +139,10 @@ class ServiceRegistry:
 
             if isinstance(annotated_param.annotation, EmptyContainerInjectionRequest):
                 warnings.warn(
-                    f"Injected[T] or Annotated[T, Inject()] is redundant in '{name}' of {target}.", stacklevel=2
+                    f"Redundant Injected[T] or Annotated[T, Inject()] in parameter '{name}' of "
+                    f"{stringify_type(target)}. See: "
+                    "https://maldoinc.github.io/wireup/latest/annotations/",
+                    stacklevel=2,
                 )
 
             self.dependencies[target][name] = annotated_param

--- a/wireup/ioc/service_registry.py
+++ b/wireup/ioc/service_registry.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import inspect
 import typing
+import warnings
 from collections import defaultdict
 from dataclasses import dataclass
 from enum import Enum, auto
@@ -15,7 +16,7 @@ from wireup.errors import (
     UnknownQualifiedServiceRequestedError,
     WireupError,
 )
-from wireup.ioc.types import AnnotatedParameter, AnyCallable
+from wireup.ioc.types import AnnotatedParameter, EmptyContainerInjectionRequest, AnyCallable
 from wireup.ioc.util import ensure_is_type, get_globals, param_get_annotation
 
 if TYPE_CHECKING:
@@ -134,6 +135,9 @@ class ServiceRegistry:
             if not annotated_param:
                 msg = f"Wireup dependencies must have types. Please add a type to the '{name}' parameter in {target}."
                 raise WireupError(msg)
+
+            if isinstance(annotated_param.annotation, EmptyContainerInjectionRequest):
+                warnings.warn(f"Injected[T] or Annotated[T, Inject()] is redundant in '{name}' of {target}.")
 
             self.dependencies[target][name] = annotated_param
 

--- a/wireup/ioc/service_registry.py
+++ b/wireup/ioc/service_registry.py
@@ -16,7 +16,7 @@ from wireup.errors import (
     UnknownQualifiedServiceRequestedError,
     WireupError,
 )
-from wireup.ioc.types import AnnotatedParameter, EmptyContainerInjectionRequest, AnyCallable
+from wireup.ioc.types import AnnotatedParameter, AnyCallable, EmptyContainerInjectionRequest
 from wireup.ioc.util import ensure_is_type, get_globals, param_get_annotation
 
 if TYPE_CHECKING:
@@ -137,7 +137,9 @@ class ServiceRegistry:
                 raise WireupError(msg)
 
             if isinstance(annotated_param.annotation, EmptyContainerInjectionRequest):
-                warnings.warn(f"Injected[T] or Annotated[T, Inject()] is redundant in '{name}' of {target}.")
+                warnings.warn(
+                    f"Injected[T] or Annotated[T, Inject()] is redundant in '{name}' of {target}.", stacklevel=2
+                )
 
             self.dependencies[target][name] = annotated_param
 


### PR DESCRIPTION
## Why

Worked on https://github.com/maldoinc/wireup/issues/68

> The use of Injected[T]/ Annotated[T, Inject()] is required when Wireup injects in foreign targets but not necessary in its own services. If a Wireup service has any annotations of that form it should warn and let the user know it's unnecessary. This can be done in the registry when adding dependencies by checking for instances of EmptyContainerInjectionRequest which is what Inject() produces.

## What 
- In `target_init_context`, check if annotated_param.annotation is an instance of `EmptyContainerInjectionRequest`.
- Add a test case asserting this warning is raised or not.


```python
from wireup import service, Inject, Injected, inject_from_container
import wireup
from typing import Annotated
import os

@service
class A:
    def buy(self) -> None:
        print("Database: buy")

@service
class B:
    def __init__(self, a: Injected[A]) -> None:
        self.a = a
if __name__ == "__main__":
    container = wireup.create_sync_container(services=[A, B])
```

```console
/Users/stock/ghq/github.com/yutaroyamanaka/wireup/wireup/ioc/service_registry.py:116: UserWarning: Injected[T] or Annotated[T, Inject()] is redundant in 'a' of <class '__main__.B'>.
  self.target_init_context(obj)
```

@maldoinc 
Please talk to me if my understanding is not correct!