### PR TITLE
fix: make Django request factory explicitly scoped

### DIFF
--- a/wireup/integration/django/apps.py
+++ b/wireup/integration/django/apps.py
@@ -65,7 +65,7 @@ def wireup_middleware(
     return sync_inner
 
 
-@service
+@service(lifetime="scoped")
 def _django_request_factory() -> HttpRequest:
     try:
         return current_request.get()


### PR DESCRIPTION
The `_django_request_factory` should have an explicit scoped lifetime since `HttpRequest` instances are inherently request-scoped and should not be shared across different requests.