### PR TITLE
fix `asyncio.iscoroutinefunction` `DeprecationWarning`

### DIFF
--- a/wireup/_decorators.py
+++ b/wireup/_decorators.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import asyncio
 import contextlib
 import functools
 import inspect

--- a/wireup/integration/django/apps.py
+++ b/wireup/integration/django/apps.py
@@ -1,4 +1,3 @@
-import asyncio
 import functools
 import importlib
 import inspect


### PR DESCRIPTION
I was setting up `wireup` in a fresh new project using python 3.14 and saw this while running some tests:

```
DeprecationWarning: 'asyncio.iscoroutinefunction' is deprecated and slated for removal in Python 3.16; 
use inspect.iscoroutinefunction() instead
    if asyncio.iscoroutinefunction(target) and isinstance(container, SyncContainer):
```

This PR fixes this warning.

`pytest` also outputted another warning but I'm not really sure how to fix this one tho:

```
/.venv/lib/python3.14/site-packages/eval_type_backport/eval_type_backport.py:227: 
DeprecationWarning: Failing to pass a value to the 'type_params' parameter of 'typing._eval_type' 
is deprecated, as it leads to incorrect behaviour when calling typing._eval_type on a 
stringified annotation that references a PEP 695 type parameter. It will be disallowed in Python 3.15.
    return typing._eval_type(value, globalns, localns, *args, **kwargs)  # type: ignore
```