### PR TITLE
Graph renderer

### DIFF
--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -15,6 +15,7 @@ nav:
       - Resource Management: resources.md
       - Interfaces: interfaces.md
       - Function Injection: function_injection.md
+      - Interactive Graph: interactive_graph.md
     - Advanced Patterns:
       - Reusable Bundles: reusable_bundles.md
       - Conditional Registration: conditional_registration.md
@@ -30,6 +31,7 @@ nav:
     - Web Frameworks:
       - Django: 
         - Django Integration: integrations/django/index.md
+        - Interactive Graph: integrations/django/interactive_graph.md
         - Setup and Installation: integrations/django/setup.md
         - Inject in Views: integrations/django/view_injection.md
         - Request-Time Injection: integrations/django/request_time_injection.md

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -20,6 +20,7 @@ nav:
       - Conditional Registration: conditional_registration.md
       - Generic Dependencies: generic_dependencies.md
     - Guides:
+      - Packaging Injectables: packaging_injectables.md
       - Testing: testing.md
       - Upgrading: upgrading.md
       - Versioning: versioning.md

--- a/docs/pages/index.md
+++ b/docs/pages/index.md
@@ -3,6 +3,7 @@
 Type-driven dependency injection for Python. Wireup is battle-tested in production, thread-safe, no-GIL (PEP 703) ready,
 and designed to fail fast: **if the container starts, it works**.
 
+
 ![Scoped Performance](img/benchmarks_scoped_light.svg#only-light)
 ![Scoped Performance](img/benchmarks_scoped_dark.svg#only-dark)
 
@@ -11,6 +12,20 @@ and designed to fail fast: **if the container starts, it works**.
 </i>
 </p>
 <p align="center"><i></i></p>
+
+---
+
+!!! interactive-graph "Interactive Graph"
+
+    Turn your container into an interactive dependency graph. Explore routes, functions, services, factories,
+    configuration, and scopes in a live page with search, grouping, and dependency tracing.
+
+    Learn how it works and explore it on an demo pet store app:
+
+    [Documentation](interactive_graph.md){ .md-button target="_blank" }
+    [:octicons-arrow-right-24: Live Demo](wireup_graph/pet_store.html){ .md-button .md-button--primary target="_blank" }
+
+---
 
 <div class="grid cards annotate index-cards" markdown>
 

--- a/docs/pages/integrations/django/index.md
+++ b/docs/pages/integrations/django/index.md
@@ -46,6 +46,16 @@ Wireup integrates with Django at both request scope and application scope. Use `
 `@inject_app` for non-request entry points, while keeping services as ordinary Python classes that are easy to test and
 reuse.
 
+!!! interactive-graph "Interactive Graph"
+
+    Turn your container into an interactive dependency graph. Explore routes, functions, services, factories,
+    configuration, and scopes in a live page with search, grouping, and dependency tracing.
+
+    Django can expose it with a small explicit view, and the same renderer is available for other apps too.
+
+    [Documentation](interactive_graph.md){ .md-button }
+    [:octicons-arrow-right-24: Live Demo](../../wireup_graph/pet_store.html){ .md-button .md-button--primary target="_blank" }
+
 ## Quick Start
 
 This is the shortest path to a working endpoint with explicit injection.
@@ -109,6 +119,7 @@ Run the app with `python manage.py runserver`, then open `http://127.0.0.1:8000/
 ## Detailed Guides
 
 - [Django Setup and Installation](setup.md): installation, middleware placement, and settings/config integration.
+- [Interactive Graph](interactive_graph.md): expose the graph page in Django and gate it by environment.
 - [Inject in Views](view_injection.md): core Django, DRF, Ninja, forms, and request-scoped patterns.
 - [Request-Time Injection](request_time_injection.md): reusable decorators, middleware entry points, and direct container access.
 - [App-Level Injection](app_injection.md): management commands, Django 6 background tasks, signals, checks, and scripts with `@inject_app`.

--- a/docs/pages/integrations/django/interactive_graph.md
+++ b/docs/pages/integrations/django/interactive_graph.md
@@ -1,0 +1,70 @@
+---
+description: Wireup interactive dependency graph for Django: expose the graph page, understand what it shows, and gate it by environment.
+---
+
+## Enable The Interactive Graph
+
+Create a small view that renders the graph page from the application container:
+
+```python title="mysite/wireup_graph.py"
+from django.http import HttpRequest, HttpResponse
+from wireup.integration.django import get_app_container
+from wireup.renderer.full_page import GraphEndpointOptions, render_graph_page
+
+
+def wireup_graph(_request: HttpRequest) -> HttpResponse:
+    return HttpResponse(
+        render_graph_page(
+            get_app_container(),
+            title="My Django App - Wireup Graph",
+            options=GraphEndpointOptions(base_module="mysite"),
+        ),
+        content_type="text/html",
+    )
+```
+
+Then mount it in your URLconf:
+
+```python title="mysite/urls.py"
+from django.conf import settings
+from django.urls import path
+
+from mysite.wireup_graph import wireup_graph
+
+urlpatterns = [
+    # ...your existing routes...
+]
+
+if settings.DEBUG:
+    urlpatterns.append(path("_wireup", wireup_graph))
+```
+
+Then open `http://127.0.0.1:8000/_wireup`.
+
+## What It Shows
+
+The graph can include:
+
+- services and factories
+- configuration nodes
+- singleton, scoped, and transient lifetimes
+- discovered Django consumers that the graph can infer from the loaded app state
+
+## Environment Gating
+
+Because the graph exposes internal implementation details, it is best treated as a development tool.
+
+A typical pattern is to mount the route only in local or non-production environments:
+
+```python title="mysite/urls.py"
+if settings.DEBUG:
+    urlpatterns.append(path("_wireup", wireup_graph))
+```
+
+If you need stricter control, omit the route entirely in production or protect it like any other internal debug page.
+
+## Related
+
+- [Django Integration](index.md)
+- [General Interactive Graph Docs](../../interactive_graph.md)
+- [Django Request-Time Injection](request_time_injection.md)

--- a/docs/pages/integrations/fastapi/index.md
+++ b/docs/pages/integrations/fastapi/index.md
@@ -47,7 +47,7 @@ description: FastAPI dependency injection with Wireup: type-safe DI for routes, 
     Learn how it works and explore it on an demo pet store app:
 
     [Documentation](interactive_graph.md){ .md-button target="_blank" }
-    [:octicons-arrow-right-24: Live Demo](wireup_graph/pet_store.html){ .md-button .md-button--primary target="_blank" }
+    [:octicons-arrow-right-24: Live Demo](../../wireup_graph/pet_store.html){ .md-button .md-button--primary target="_blank" }
 
 ## Quick Start
 

--- a/docs/pages/integrations/fastapi/index.md
+++ b/docs/pages/integrations/fastapi/index.md
@@ -38,12 +38,16 @@ description: FastAPI dependency injection with Wireup: type-safe DI for routes, 
 
 </div>
 
-!!! tip "Migrating from FastAPI Depends?"
+!!! interactive-graph "Interactive Graph"
 
-    Evaluating Wireup for your FastAPI project? Check out the migration page which includes common pain points with FastAPI Depends and how to solve them with Wireup as well
-    as a low-friction migration path:
+    Turn your container into an interactive dependency graph. Explore routes, functions, services, factories,
+    configuration, and scopes in a live page with search, grouping, and dependency tracing.
 
-    [Migrate from FastAPI Depends to Wireup](../../migrate_to_wireup/fastapi_depends.md).
+
+    Learn how it works and explore it on an demo pet store app:
+
+    [Documentation](interactive_graph.md){ .md-button target="_blank" }
+    [:octicons-arrow-right-24: Live Demo](wireup_graph/pet_store.html){ .md-button .md-button--primary target="_blank" }
 
 ## Quick Start
 
@@ -95,6 +99,14 @@ fastapi dev main.py
 - [Background Tasks](background_tasks.md): inject dependencies into scheduled callbacks with `WireupTask`.
 - [FastAPI Testing](testing.md): `TestClient` lifespan usage, overrides, and request-lifecycle tests.
 - [Troubleshooting](troubleshooting.md): common setup/runtime errors and fast fixes.
+
+!!! tip "Migrating from FastAPI Depends?"
+
+    Evaluating Wireup for your FastAPI project? Check out the migration page which includes common pain points with FastAPI Depends and how to solve them with Wireup as well
+    as a low-friction migration path:
+
+    [Migrate from FastAPI Depends to Wireup](../../migrate_to_wireup/fastapi_depends.md).
+
 
 ## API Reference
 

--- a/docs/pages/integrations/flask/index.md
+++ b/docs/pages/integrations/flask/index.md
@@ -18,6 +18,16 @@ Dependency injection for Flask is available in the `wireup.integration.flask` mo
 
 </div>
 
+!!! interactive-graph "Interactive Graph"
+
+    Turn your container into an interactive dependency graph. Explore routes, functions, services, factories,
+    configuration, and scopes in a live page with search, grouping, and dependency tracing.
+
+    Learn how it works and explore it on an demo pet store app:
+
+    [Documentation](interactive_graph.md){ .md-button target="_blank" }
+    [:octicons-arrow-right-24: Live Demo](wireup_graph/pet_store.html){ .md-button .md-button--primary target="_blank" }
+
 ### Initialize the integration
 
 First, [create a sync container](../../container.md) with your dependencies:
@@ -44,6 +54,18 @@ Then initialize the integration by calling `wireup.integration.flask.setup` afte
 # Initialize the integration.
 # Must be called after views and configuration have been added.
 wireup.integration.flask.setup(container, app)
+```
+
+To expose the interactive dependency graph page at `/_wireup`, enable the graph endpoint during setup:
+
+```python
+from wireup.integration.flask import GraphEndpointOptions
+
+wireup.integration.flask.setup(
+    container,
+    app,
+    add_graph_endpoint=True,
+)
 ```
 
 ### Inject in Flask Views

--- a/docs/pages/integrations/flask/index.md
+++ b/docs/pages/integrations/flask/index.md
@@ -26,7 +26,7 @@ Dependency injection for Flask is available in the `wireup.integration.flask` mo
     Learn how it works and explore it on an demo pet store app:
 
     [Documentation](interactive_graph.md){ .md-button target="_blank" }
-    [:octicons-arrow-right-24: Live Demo](wireup_graph/pet_store.html){ .md-button .md-button--primary target="_blank" }
+    [:octicons-arrow-right-24: Live Demo](../../wireup_graph/pet_store.html){ .md-button .md-button--primary target="_blank" }
 
 ### Initialize the integration
 

--- a/docs/pages/interactive_graph.md
+++ b/docs/pages/interactive_graph.md
@@ -7,7 +7,6 @@
 
     Learn how it works and explore it on an demo pet store app:
 
-    [Documentation](interactive_graph.md){ .md-button target="_blank" }
     [:octicons-arrow-right-24: Live Demo](wireup_graph/pet_store.html){ .md-button .md-button--primary target="_blank" }
 
 Wireup can render your dependency graph as an interactive page, including:

--- a/docs/pages/interactive_graph.md
+++ b/docs/pages/interactive_graph.md
@@ -1,0 +1,94 @@
+# Interactive Graph
+
+!!! interactive-graph "Interactive Graph"
+
+    Turn your container into an interactive dependency graph. Explore routes, functions, services, factories,
+    configuration, and scopes in a live page with search, grouping, and dependency tracing.
+
+    Learn how it works and explore it on an demo pet store app:
+
+    [Documentation](interactive_graph.md){ .md-button target="_blank" }
+    [:octicons-arrow-right-24: Live Demo](wireup_graph/pet_store.html){ .md-button .md-button--primary target="_blank" }
+
+Wireup can render your dependency graph as an interactive page, including:
+
+- routes and injected functions for selected frameworks
+- services and factories
+- configuration nodes
+- singleton, scoped, and transient lifetimes
+
+This is one of the fastest ways to understand how a real application is wired together without relying on a static dump
+or a handwritten diagram.
+
+## Preview
+
+![Wireup interactive dependency graph demo](img/pet_store_demo.gif)
+
+
+## Automatic with FastAPI and Flask
+
+FastAPI and Flask can expose the graph page automatically at `/_wireup`.
+
+### FastAPI
+
+```python
+from wireup.integration.fastapi import GraphEndpointOptions
+import wireup.integration.fastapi
+
+wireup.integration.fastapi.setup(
+    container,
+    app,
+    add_graph_endpoint=True,
+)
+```
+
+### Flask
+
+```python
+from wireup.integration.flask import GraphEndpointOptions
+import wireup.integration.flask
+
+wireup.integration.flask.setup(
+    container,
+    app,
+    add_graph_endpoint=True,
+)
+```
+
+## Use in other frameworks
+
+If your framework does not have automatic graph-page setup, you can still generate the graph yourself from Python.
+
+### 1. Build graph data
+
+```python
+from wireup.renderer.core import GraphOptions, to_graph_data
+
+graph_data = to_graph_data(
+    container,  # or get_app_container() if the integration provides it
+    options=GraphOptions(base_module="myapp"),
+)
+```
+
+### 2. Render it as HTML
+
+```python
+from wireup.renderer.full_page import full_page_renderer
+
+html = full_page_renderer(graph_data, title="My App - Wireup Graph")
+```
+
+### 3. Return it from a route
+
+```python
+@app.get("/_wireup")
+def wireup_graph():
+    graph_data = to_graph_data(container, options=GraphOptions(base_module="myapp"))
+    html = full_page_renderer(graph_data, title="My App - Wireup Graph")
+
+    return HTMLResponse(html)
+```
+
+
+!!! tip
+    Make sure to permission this endpoint appropriately in production since it exposes internal implementation details. You can disable it by omitting `add_graph_endpoint=True` or by not registering the route at all.

--- a/docs/pages/packaging_injectables.md
+++ b/docs/pages/packaging_injectables.md
@@ -1,0 +1,105 @@
+Use this guide when you want to package and distribute injectables across applications, teams, or internal
+libraries. Wireup always receives a list of injectables, so the main choice is how your package exposes that
+list.
+
+## 1. Export A Module Or Package
+
+Use this when the injectables are fixed and the application does not need to choose between variants. 
+Wireup's own integrations use the same idea. For example, `wireup.integration.fastapi` is a module with injectables that can be passed directly in `injectables=[...]` and exposes FastAPI `Request`, `WebSocket`, and `WireupTask`.
+
+Example:
+
+```python title="team_name_sqlalchemy/__init__.py"
+@injectable
+def database_session() -> DatabaseSession: ...
+
+@injectable
+class UserRepository: ...
+
+```
+
+```python title="app.py"
+import wireup
+import team_name_sqlalchemy
+
+
+container = wireup.create_sync_container(
+    injectables=[team_name_sqlalchemy],
+)
+```
+
+This is the simplest option. It works well for internal packages and libraries with a single default setup.
+
+## 2. Export A List Of Injectables
+
+Use this when you want the package to export an explicit list of injectables instead of relying on module
+scanning.
+
+```python title="team_name_sqlalchemy/__init__.py"
+@injectable
+def database_session() -> DatabaseSession: ...
+
+@injectable
+class UserRepository: ..
+
+INJECTABLES = [database_session, UserRepository]
+```
+
+```python title="app.py"
+import wireup
+import team_name_sqlalchemy
+
+
+container = wireup.create_sync_container(
+    injectables=[*team_name_sqlalchemy.INJECTABLES],
+)
+```
+
+## 3. Export A Function That Returns Injectables
+
+Use this when the package exposes parameters of its own, such as backend choices or feature flags.
+
+```python title="team_name_sqlalchemy/__init__.py"
+from typing import Literal, Protocol
+
+from wireup import injectable
+
+
+class Cache(Protocol): ...
+
+
+@injectable(as_type=Cache)
+class RedisCache: ...
+
+@injectable(as_type=Cache)
+class MemcachedCache: ...
+
+
+def make_injectables(
+    *,
+    backend: Literal["redis", "memcached"],
+) -> list[object]:
+    if backend == "redis":
+        return [RedisCache]
+
+    return [MemcachedCache]
+```
+
+```python title="app.py"
+import wireup
+from team_name_sqlalchemy import make_injectables
+
+
+container = wireup.create_sync_container(
+    injectables=[*make_injectables(backend=settings.cache_backend)],
+)
+```
+
+For reusable provider-style bundles or registering the same subgraph more than once, see
+[Reusable Bundles](reusable_bundles.md).
+
+## Which One Should You Pick?
+
+- Use a module when the package has one setup and consumers do not need to choose between variants.
+- Use a list when you want explicit control over what gets registered without module scanning.
+- Use a function when the package exposes parameters that consumers must provide when building the injectables.

--- a/docs/pages/stylesheets/extra.css
+++ b/docs/pages/stylesheets/extra.css
@@ -30,3 +30,24 @@ body[data-md-color-scheme="slate"] .grid.cards>ul>li {
 .color-django {
     color: #0C4B33 !important;
 }
+
+:root {
+    --md-admonition-icon--interactive-graph: url('data:image/svg+xml;charset=utf-8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 48 48"><path d="M42.3 24l3.4-5.1a2 2 0 0 0 .2-1.7 1.8 1.8 0 0 0-1.2-1.2l-5.9-2.4-.5-5.9a2.1 2.1 0 0 0-.7-1.5 2 2 0 0 0-1.7-.3l-6.3 1.3-4.1-4.6a2.2 2.2 0 0 0-3 0l-4.1 4.6-6.3-1.3a2 2 0 0 0-1.7.3 2.1 2.1 0 0 0-.7 1.5l-.5 5.9L3.3 16a1.8 1.8 0 0 0-1.2 1.2 2 2 0 0 0 .2 1.7L5.7 24l-3.4 5.1a2 2 0 0 0 1 2.9l5.9 2.4.5 5.9a2.1 2.1 0 0 0 .7 1.5 2 2 0 0 0 1.7.3l6.3-1.3 4.1 4.5a2 2 0 0 0 3 0l4.1-4.5 6.3 1.3a2 2 0 0 0 1.7-.3 2.1 2.1 0 0 0 .7-1.5l.5-5.9 5.9-2.4a2 2 0 0 0 1-2.9ZM18 31.1l-4.2-3.2-1.1-.9h-.1l.6 1.4 1.7 4-2.1.8-3.5-8.6 2.1-.8 4.3 3.2 1.1.9h0a11.8 11.8 0 0 0-.6-1.3l-1.6-4.1 2.1-.9 3.5 8.6Zm3.3-1.3-3.5-8.7 6.6-2.6.7 1.8L20.7 22l.6 1.6L25.1 22l.7 1.7L22 25.2l.7 1.9 4.5-1.8.7 1.8Zm13.9-5.7-2.6-3.7-.9-1.5h-.1a14.7 14.7 0 0 1 .4 1.7l.8 4.5-2.1.9-5.9-7.7 2.2-.9 2.3 3.3 1.3 2h0a22.4 22.4 0 0 1-.4-2.3l-.7-4 2-.8L33.8 19 35 20.9h0s-.2-1.4-.4-2.4L34 14.6l2.1-.9 1.2 9.6Z"/></svg>');
+}
+
+.md-typeset .admonition.interactive-graph,
+.md-typeset details.interactive-graph {
+    border-color: #007acc;
+}
+
+.md-typeset .interactive-graph > .admonition-title,
+.md-typeset .interactive-graph > summary {
+    background-color: rgba(0, 122, 204, 0.12);
+}
+
+.md-typeset .interactive-graph > .admonition-title::before,
+.md-typeset .interactive-graph > summary::before {
+    background-color: #007acc;
+    -webkit-mask-image: var(--md-admonition-icon--interactive-graph);
+            mask-image: var(--md-admonition-icon--interactive-graph);
+}

--- a/docs/pages/wireup_graph/pet_store.html
+++ b/docs/pages/wireup_graph/pet_store.html
@@ -1,0 +1,1677 @@
+<!doctype html>
+<html lang="en">
+
+<head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>Wireup Pet Store Demo - Wireup Graph</title>
+    <script>
+        (() => {
+            const storageKey = `wireup:theme:${document.title || "wireup-graph"}`;
+            const storedTheme = window.localStorage.getItem(storageKey);
+            const theme = storedTheme === "light" || storedTheme === "dark" ? storedTheme : "dark";
+            document.documentElement.setAttribute("data-theme", theme);
+        })();
+    </script>
+    <style>
+        :root {
+            --font-ui: "Inter", "Segoe UI", sans-serif;
+            --font-display: "Space Grotesk", "Segoe UI", sans-serif;
+            --radius-lg: 18px;
+            --radius-md: 12px;
+            --radius-sm: 10px;
+            --shadow: 0 24px 60px rgba(0, 0, 0, 0.24);
+            --bg: #0f1321;
+            --bg-elevated: #151a2b;
+            --bg-panel: #1b2134;
+            --bg-panel-soft: #232940;
+            --bg-canvas: #0c1020;
+            --ink: #edf1ff;
+            --muted: #8f97b4;
+            --line: rgba(151, 161, 198, 0.18);
+            --line-strong: rgba(151, 161, 198, 0.28);
+            --accent: #ff3d7f;
+            --accent-soft: rgba(255, 61, 127, 0.16);
+            --accent-strong: #36d2ff;
+            --service: #2a3552;
+            --factory: #243c56;
+            --consumer: #2f314f;
+            --config: #47305d;
+            --group: #1a2237;
+            --edge: #69718c;
+            --edge-strong: #8a93b3;
+            --detail-bg: rgba(18, 23, 38, 0.96);
+            --pill-bg: rgba(255, 255, 255, 0.04);
+            --button-bg: rgba(255, 255, 255, 0.06);
+            --button-bg-hover: rgba(255, 255, 255, 0.11);
+            --node-text: #edf1ff;
+            --panel-blur: blur(18px);
+        }
+
+        html[data-theme="light"] body {
+            --shadow: 0 22px 54px rgba(46, 55, 80, 0.16);
+            --bg: #eef2fb;
+            --bg-elevated: #f7f9ff;
+            --bg-panel: rgba(255, 255, 255, 0.92);
+            --bg-panel-soft: #f2f5ff;
+            --bg-canvas: #f8faff;
+            --ink: #1b2234;
+            --muted: #68728f;
+            --line: rgba(84, 97, 132, 0.14);
+            --line-strong: rgba(84, 97, 132, 0.24);
+            --accent: #d61d61;
+            --accent-soft: rgba(214, 29, 97, 0.12);
+            --accent-strong: #0f8db3;
+            --service: #e7eeff;
+            --factory: #e0efff;
+            --consumer: #e9e5ff;
+            --config: #f1e5ff;
+            --group: #e7ebf5;
+            --edge: #7a859f;
+            --edge-strong: #58637f;
+            --detail-bg: rgba(255, 255, 255, 0.97);
+            --pill-bg: rgba(27, 34, 52, 0.04);
+            --button-bg: rgba(27, 34, 52, 0.05);
+            --button-bg-hover: rgba(27, 34, 52, 0.09);
+            --node-text: #1b2234;
+        }
+
+        * {
+            box-sizing: border-box;
+        }
+
+        html,
+        body {
+            margin: 0;
+            min-height: 100%;
+            font-family: var(--font-ui);
+            background:
+                radial-gradient(circle at top left, rgba(255, 61, 127, 0.16), transparent 22%),
+                radial-gradient(circle at top right, rgba(54, 210, 255, 0.12), transparent 20%),
+                linear-gradient(180deg, var(--bg-elevated) 0%, var(--bg) 100%);
+            color: var(--ink);
+        }
+
+        body {
+            color-scheme: dark;
+        }
+
+        html[data-theme="light"] body {
+            color-scheme: light;
+        }
+
+        button,
+        input,
+        select {
+            font: inherit;
+        }
+
+        .app-shell {
+            min-height: 100vh;
+            display: grid;
+            grid-template-rows: 58px 1fr;
+        }
+
+        .panel {
+            background: var(--bg-panel);
+            border: 1px solid var(--line);
+            border-radius: var(--radius-lg);
+            box-shadow: var(--shadow);
+            backdrop-filter: var(--panel-blur);
+        }
+
+        .topbar {
+            display: grid;
+            grid-template-columns: auto minmax(0, 1fr) auto;
+            gap: 14px;
+            align-items: center;
+            padding: 0 18px;
+            border-bottom: 1px solid var(--line);
+            background: rgba(13, 18, 31, 0.72);
+            backdrop-filter: blur(18px);
+            position: sticky;
+            top: 0;
+            z-index: 10;
+        }
+
+        html[data-theme="light"] .topbar {
+            background: rgba(245, 248, 255, 0.88);
+        }
+
+        .brand {
+            display: inline-flex;
+            align-items: center;
+            min-width: 0;
+            font-family: var(--font-display);
+            font-weight: 700;
+            letter-spacing: 0.04em;
+            text-transform: uppercase;
+            color: var(--ink);
+        }
+
+        .topbar-title {
+            min-width: 0;
+            display: inline-flex;
+            align-items: center;
+            gap: 10px;
+            padding: 10px 14px;
+            border-radius: var(--radius-sm);
+            border: 1px solid var(--line-strong);
+            background: var(--button-bg);
+            color: var(--ink);
+            overflow: hidden;
+        }
+
+        .topbar-title::before {
+            content: "";
+            width: 8px;
+            height: 8px;
+            border-radius: 999px;
+            background: #3ddc97;
+            box-shadow: 0 0 12px rgba(61, 220, 151, 0.7);
+            flex: 0 0 auto;
+        }
+
+        .topbar-title span {
+            overflow: hidden;
+            text-overflow: ellipsis;
+            white-space: nowrap;
+        }
+
+        .topbar-actions {
+            display: inline-flex;
+            align-items: center;
+            gap: 10px;
+            justify-self: end;
+        }
+
+        .button,
+        .details-pill {
+            display: inline-flex;
+            align-items: center;
+            justify-content: center;
+            gap: 8px;
+            min-height: 40px;
+            border-radius: var(--radius-sm);
+            border: 1px solid var(--line-strong);
+            background: var(--button-bg);
+            color: var(--ink);
+            cursor: pointer;
+            transition: background 120ms ease, border-color 120ms ease, transform 120ms ease;
+        }
+
+        .button {
+            padding: 0 14px;
+            font-size: 0.78rem;
+            font-weight: 700;
+            letter-spacing: 0.05em;
+            text-transform: uppercase;
+        }
+
+        .button:hover,
+        .details-pill:hover {
+            background: var(--button-bg-hover);
+            border-color: rgba(255, 61, 127, 0.38);
+        }
+
+        .button-accent {
+            color: #ff6f9d;
+            border-color: rgba(255, 61, 127, 0.38);
+            box-shadow: inset 0 0 0 1px rgba(255, 61, 127, 0.08);
+        }
+
+        .controls-menu {
+            position: relative;
+        }
+
+        .controls-panel {
+            position: absolute;
+            top: calc(100% + 10px);
+            right: 0;
+            width: min(280px, calc(100vw - 32px));
+            padding: 12px;
+            border-radius: 14px;
+            border: 1px solid var(--line-strong);
+            background: var(--detail-bg);
+            box-shadow: var(--shadow);
+            display: grid;
+            gap: 10px;
+            z-index: 20;
+        }
+
+        .controls-panel[hidden] {
+            display: none;
+        }
+
+        .controls-section-title {
+            margin: 2px 2px -2px;
+            font-size: 0.7rem;
+            font-weight: 800;
+            letter-spacing: 0.14em;
+            text-transform: uppercase;
+            color: var(--muted);
+        }
+
+        .controls-panel .button {
+            width: 100%;
+            justify-content: flex-start;
+            text-transform: none;
+            letter-spacing: 0.02em;
+            font-size: 0.86rem;
+            font-weight: 600;
+        }
+
+        .workspace {
+            min-height: 0;
+            display: grid;
+            grid-template-columns: 332px minmax(0, 1fr);
+        }
+
+        .sidebar {
+            padding: 20px;
+            border-right: 1px solid var(--line);
+            background: rgba(18, 22, 37, 0.82);
+            display: grid;
+            grid-template-rows: auto auto minmax(0, 1fr);
+            gap: 18px;
+            min-height: 0;
+        }
+
+        html[data-theme="light"] .sidebar {
+            background: rgba(248, 250, 255, 0.92);
+        }
+
+        .sidebar-section {
+            border-bottom: 1px solid var(--line);
+            padding-bottom: 18px;
+        }
+
+        .sidebar-section:last-child {
+            border-bottom: 0;
+            padding-bottom: 0;
+            min-height: 0;
+            display: grid;
+            grid-template-rows: auto auto 1fr;
+        }
+
+        .eyebrow {
+            margin: 0 0 10px;
+            font-size: 0.72rem;
+            font-weight: 800;
+            letter-spacing: 0.16em;
+            text-transform: uppercase;
+            color: var(--muted);
+        }
+
+        .sidebar-text {
+            margin: 10px 0 0;
+            line-height: 1.6;
+            color: var(--muted);
+        }
+
+        .field,
+        .group {
+            display: flex;
+            flex-direction: column;
+            gap: 8px;
+            min-width: 0;
+        }
+
+        .field label,
+        .group .label {
+            font-size: 0.72rem;
+            font-weight: 800;
+            text-transform: uppercase;
+            letter-spacing: 0.12em;
+            color: var(--muted);
+        }
+
+        input[type="search"] {
+            width: 100%;
+            border: 1px solid var(--line-strong);
+            background: var(--bg-panel-soft);
+            border-radius: var(--radius-sm);
+            padding: 12px 14px;
+            color: var(--ink);
+        }
+
+        select {
+            width: 100%;
+            border: 1px solid var(--line-strong);
+            background: var(--bg-panel-soft);
+            border-radius: var(--radius-sm);
+            padding: 12px 14px;
+            color: var(--ink);
+        }
+
+        .toggle-list,
+        .legend-list {
+            display: grid;
+            gap: 10px;
+        }
+
+        .toggle,
+        .legend-pill {
+            display: inline-flex;
+            align-items: flex-start;
+            gap: 8px;
+            min-height: 40px;
+            font-size: 0.92rem;
+            line-height: 1.35;
+            border: 1px solid var(--line-strong);
+            border-radius: var(--radius-sm);
+            padding: 9px 12px;
+            background: var(--pill-bg);
+        }
+
+        .legend-copy {
+            display: grid;
+            gap: 2px;
+            min-width: 0;
+        }
+
+        .legend-title {
+            font-weight: 600;
+            color: var(--ink);
+        }
+
+        .legend-title[data-tooltip] {
+            cursor: help;
+        }
+
+        .legend-description {
+            font-size: 0.9rem;
+            color: var(--muted);
+        }
+
+        .toggle input {
+            accent-color: var(--accent);
+            margin: 2px 0 0;
+        }
+
+        .toggle-copy {
+            display: grid;
+            gap: 2px;
+            min-width: 0;
+        }
+
+        .toggle-title {
+            font-weight: 600;
+            color: var(--ink);
+        }
+
+        .toggle-description {
+            font-size: 0.9rem;
+            color: var(--muted);
+        }
+
+        .legend-pill.service {
+            background: var(--service);
+        }
+
+        .legend-pill.factory {
+            background: var(--factory);
+        }
+
+        .legend-pill.consumer {
+            background: var(--consumer);
+        }
+
+        .legend-pill.config {
+            background: var(--config);
+        }
+
+        .legend-pill.lifetime {
+            border-color: var(--line-strong);
+            border-width: 2px;
+        }
+
+        .legend-pill.singleton {
+            border-style: solid;
+        }
+
+        .legend-pill.scoped {
+            border-style: dashed;
+        }
+
+        .legend-pill.transient {
+            border-style: dotted;
+        }
+
+        .viewer {
+            position: relative;
+            min-height: 0;
+            background:
+                radial-gradient(circle at 18% 18%, rgba(54, 210, 255, 0.08), transparent 20%),
+                radial-gradient(circle at 74% 16%, rgba(255, 61, 127, 0.07), transparent 22%),
+                linear-gradient(180deg, rgba(255, 255, 255, 0.01), transparent 42%),
+                var(--bg-canvas);
+            overflow: hidden;
+        }
+
+        #cy {
+            position: absolute;
+            inset: 0;
+        }
+
+        .details {
+            position: absolute;
+            right: 20px;
+            bottom: 20px;
+            width: min(380px, calc(100% - 40px));
+            padding: 18px;
+            border-radius: 16px;
+            border: 1px solid var(--line-strong);
+            background: var(--detail-bg);
+            box-shadow: var(--shadow);
+            z-index: 2;
+        }
+
+        .details h2 {
+            margin: 0 0 8px;
+            font-family: var(--font-display);
+            font-size: 1.08rem;
+        }
+
+        .details-subtitle {
+            margin: 0 0 12px;
+            font-size: 0.9rem;
+            color: var(--muted);
+        }
+
+        .details-empty {
+            margin: 0;
+            font-size: 0.9rem;
+            color: var(--muted);
+        }
+
+        .details-kind-box {
+            width: 12px;
+            height: 12px;
+            border-radius: 3px;
+            border: 1px solid rgba(0, 0, 0, 0.12);
+            flex: 0 0 auto;
+        }
+
+        .details-legend {
+            display: grid;
+            gap: 6px;
+            margin: 0 0 10px;
+            font-size: 0.82rem;
+            color: var(--muted);
+        }
+
+        .details-legend-item {
+            display: flex;
+            align-items: center;
+            gap: 6px;
+        }
+
+        .details-section {
+            margin: 0 0 12px;
+        }
+
+        .details-section-title {
+            margin: 0 0 6px;
+            font-size: 0.78rem;
+            font-weight: 700;
+            letter-spacing: 0.04em;
+            text-transform: uppercase;
+            color: var(--muted);
+        }
+
+        .details-pills {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 6px;
+            min-height: 28px;
+        }
+
+        .details-pill {
+            align-items: center;
+            gap: 6px;
+            min-width: 0;
+            font-size: 0.82rem;
+            line-height: 1.2;
+            padding: 0 12px;
+        }
+
+        .details-pill.empty {
+            color: var(--muted);
+            cursor: default;
+            background: var(--button-bg);
+        }
+
+        .details-pill.empty:hover {
+            border-color: var(--line-strong);
+        }
+
+        .details-pill-swatch {
+            width: 10px;
+            height: 10px;
+            border-radius: 999px;
+            flex: 0 0 auto;
+        }
+
+        .details dl {
+            margin: 0;
+            display: grid;
+            grid-template-columns: max-content minmax(0, 1fr);
+            gap: 8px 10px;
+            font-size: 0.9rem;
+        }
+
+        .details dt {
+            color: var(--muted);
+            white-space: nowrap;
+        }
+
+        .details dd {
+            margin: 0;
+            overflow-wrap: anywhere;
+            word-break: break-word;
+        }
+
+        .details-meta-code {
+            font-size: 0.84rem;
+            line-height: 1.35;
+            color: var(--muted);
+            font-family: "IBM Plex Mono", "SFMono-Regular", monospace;
+        }
+
+        .details-value {
+            display: inline-flex;
+            align-items: center;
+            gap: 8px;
+            min-width: 0;
+        }
+
+        .theme-button .theme-button-light,
+        html[data-theme="light"] .theme-button .theme-button-dark {
+            display: inline;
+        }
+
+        .theme-button .theme-button-dark,
+        html[data-theme="light"] .theme-button .theme-button-light {
+            display: none;
+        }
+
+        @media (max-width: 980px) {
+            .topbar {
+                grid-template-columns: 1fr;
+                padding: 14px;
+            }
+
+            .workspace {
+                grid-template-columns: 1fr;
+            }
+
+            .sidebar {
+                border-right: 0;
+                border-bottom: 1px solid var(--line);
+            }
+
+            .details {
+                position: static;
+                width: auto;
+                margin: 20px;
+            }
+
+            .controls-panel {
+                position: fixed;
+                top: 72px;
+                right: 16px;
+            }
+        }
+    </style>
+</head>
+
+<body>
+    <div class="app-shell">
+        <header class="topbar">
+            <div class="brand">
+                <span>Wireup Graph</span>
+            </div>
+
+            <div class="topbar-title">
+                <span>Wireup Pet Store Demo - Wireup Graph</span>
+            </div>
+
+            <div class="topbar-actions">
+                <div class="controls-menu">
+                    <button class="button" id="controls-toggle" type="button" aria-expanded="false"
+                        aria-controls="controls-panel">
+                        Controls
+                    </button>
+                    <div class="controls-panel" id="controls-panel" hidden>
+                        <div class="controls-section-title">View</div>
+                        <button class="button theme-button" id="theme-toggle" type="button">
+                            <span class="theme-button-light">Switch to Light Mode</span>
+                            <span class="theme-button-dark">Switch to Dark Mode</span>
+                        </button>
+                        <div class="controls-section-title">Layout</div>
+                        <button class="button" id="reset-layout" type="button">Reset Layout</button>
+                        <button class="button" id="reset-viewport" type="button">Reset Zoom</button>
+                        <div class="controls-section-title">Export</div>
+                        <button class="button button-accent" id="export-png" type="button">Export as PNG</button>
+                    </div>
+                </div>
+            </div>
+        </header>
+
+        <div class="workspace">
+            <aside class="sidebar">
+                <section class="sidebar-section">
+                    <div class="field">
+                        <label for="search">Filter nodes</label>
+                        <input id="search" type="search" placeholder="PetCatalogService, adoption, request">
+                    </div>
+                    <div class="field" style="margin-top: 14px;">
+                        <label for="layout-mode">Layout</label>
+                        <select id="layout-mode" aria-label="Graph layout">
+                            <option value="dagre">Dependency flow</option>
+                            <option value="elk">Layered</option>
+                            <option value="grid">Grid</option>
+                            <option value="circle">Circle</option>
+                            <option value="concentric">Concentric</option>
+                            <option value="breadthfirst">Classic</option>
+                        </select>
+                    </div>
+                    <p class="sidebar-text">
+                        Explore services, factories, configuration, routes, and functions from a single graph view.
+                    </p>
+                </section>
+
+                <section class="sidebar-section">
+                    <p class="eyebrow">Options</p>
+                    <div class="toggle-list">
+                        <label class="toggle">
+                            <input id="toggle-config" type="checkbox" checked>
+                            <span class="toggle-copy">
+                                <span class="toggle-title">Show configuration nodes</span>
+                                <span class="toggle-description">Display config entries that feed the selected
+                                    graph.</span>
+                            </span>
+                        </label>
+                        <label class="toggle">
+                            <input id="toggle-edge-labels" type="checkbox">
+                            <span class="toggle-copy">
+                                <span class="toggle-title">Show edge labels</span>
+                                <span class="toggle-description">Reveal parameter names on dependency
+                                    connections.</span>
+                            </span>
+                        </label>
+                        <label class="toggle">
+                            <input id="toggle-modules" type="checkbox" checked>
+                            <span class="toggle-copy">
+                                <span class="toggle-title">Group by modules</span>
+                                <span class="toggle-description">Cluster related nodes inside their source module
+                                    groups.</span>
+                            </span>
+                        </label>
+                        <label class="toggle">
+                            <input id="toggle-empty-groups" type="checkbox">
+                            <span class="toggle-copy">
+                                <span class="toggle-title">Include unused groups</span>
+                                <span class="toggle-description">Keep empty module containers visible in the
+                                    overview.</span>
+                            </span>
+                        </label>
+                    </div>
+
+                    <p class="eyebrow" style="margin-top:18px;">Legend</p>
+                    <div class="legend-list" id="legend-list">
+                        <span class="legend-pill lifetime singleton">Singleton</span>
+                        <span class="legend-pill lifetime scoped">Scoped</span>
+                        <span class="legend-pill lifetime transient">Transient</span>
+                    </div>
+                </section>
+            </aside>
+
+            <section class="viewer">
+                <div id="cy"></div>
+                <section class="details" id="details">
+                    <h2>No node selected</h2>
+                    <p class="details-empty">Left click for the full neighborhood. Right click for dependency paths
+                        only.</p>
+                </section>
+            </section>
+        </div>
+    </div>
+
+    <script id="wireup-graph-data"
+        type="application/json">{"groups":[{"id":"group_Configuration","label":"Configuration","kind":"group","module":"Configuration"},{"id":"group_FastAPI","label":"FastAPI","kind":"group","module":"FastAPI"},{"id":"group_cbr","label":"cbr","kind":"group","module":"cbr"},{"id":"group_factories","label":"factories","kind":"group","module":"factories"},{"id":"group_fastapi_services","label":"fastapi_services","kind":"group","module":"fastapi_services"},{"id":"group_pet_store_demo_app_main","label":"pet_store_demo_app.main","kind":"group","module":"pet_store_demo_app.main"},{"id":"group_services_adoption","label":"services.adoption","kind":"group","module":"services.adoption"},{"id":"group_services_audit","label":"services.audit","kind":"group","module":"services.audit"},{"id":"group_services_infra","label":"services.infra","kind":"group","module":"services.infra"},{"id":"group_services_owners","label":"services.owners","kind":"group","module":"services.owners"},{"id":"group_services_pets","label":"services.pets","kind":"group","module":"services.pets"},{"id":"group_services_session","label":"services.session","kind":"group","module":"services.session"},{"id":"group_wireup_integration_starlette","label":"wireup.integration.starlette","kind":"group","module":"wireup.integration.starlette"},{"id":"group_wireup_ioc_container","label":"wireup.ioc.container","kind":"group","module":"wireup.ioc.container"}],"nodes":[{"id":"config_auth","label":"⚙️ auth","kind":"config","lifetime":null,"module":"config","parent":"group_Configuration","original_parent":"group_Configuration","group":"Configuration","factory_name":null},{"id":"config_env","label":"⚙️ env","kind":"config","lifetime":null,"module":"config","parent":"group_Configuration","original_parent":"group_Configuration","group":"Configuration","factory_name":null},{"id":"config_infra","label":"⚙️ infra","kind":"config","lifetime":null,"module":"config","parent":"group_Configuration","original_parent":"group_Configuration","group":"Configuration","factory_name":null},{"id":"config_messaging","label":"⚙️ messaging","kind":"config","lifetime":null,"module":"config","parent":"group_Configuration","original_parent":"group_Configuration","group":"Configuration","factory_name":null},{"id":"config_pets","label":"⚙️ pets","kind":"config","lifetime":null,"module":"config","parent":"group_Configuration","original_parent":"group_Configuration","group":"Configuration","factory_name":null},{"id":"config_services","label":"⚙️ services","kind":"config","lifetime":null,"module":"config","parent":"group_Configuration","original_parent":"group_Configuration","group":"Configuration","factory_name":null},{"id":"consumer_GET_class_based_overview","label":"🌐 GET /class-based/overview","kind":"consumer","lifetime":null,"module":"pet_store_demo_app.cbr","parent":"group_FastAPI","original_parent":"group_FastAPI","group":"FastAPI","factory_name":null},{"id":"consumer_GET_db_session","label":"🌐 GET /db-session","kind":"consumer","lifetime":null,"module":"pet_store_demo_app.main","parent":"group_FastAPI","original_parent":"group_FastAPI","group":"FastAPI","factory_name":null},{"id":"consumer_GET_owners_owner_id","label":"🌐 GET /owners/{owner_id}","kind":"consumer","lifetime":null,"module":"pet_store_demo_app.main","parent":"group_FastAPI","original_parent":"group_FastAPI","group":"FastAPI","factory_name":null},{"id":"consumer_GET_pets","label":"🌐 GET /pets","kind":"consumer","lifetime":null,"module":"pet_store_demo_app.main","parent":"group_FastAPI","original_parent":"group_FastAPI","group":"FastAPI","factory_name":null},{"id":"consumer_GET_pets_pet_id","label":"🌐 GET /pets/{pet_id}","kind":"consumer","lifetime":null,"module":"pet_store_demo_app.main","parent":"group_FastAPI","original_parent":"group_FastAPI","group":"FastAPI","factory_name":null},{"id":"consumer_GET_whoami","label":"🌐 GET /whoami","kind":"consumer","lifetime":null,"module":"pet_store_demo_app.main","parent":"group_FastAPI","original_parent":"group_FastAPI","group":"FastAPI","factory_name":null},{"id":"consumer_POST_pets_pet_id_adopt","label":"🌐 POST /pets/{pet_id}/adopt","kind":"consumer","lifetime":null,"module":"pet_store_demo_app.main","parent":"group_FastAPI","original_parent":"group_FastAPI","group":"FastAPI","factory_name":null},{"id":"consumer_pet_store_demo_app_main_list_featured_pets","label":"ƒ list_featured_pets","kind":"consumer","lifetime":null,"module":"pet_store_demo_app.main","parent":"group_pet_store_demo_app_main","original_parent":"group_pet_store_demo_app_main","group":"pet_store_demo_app.main","factory_name":null},{"id":"pet_store_demo_app_cbr_DemoClassBasedHandler","label":"🐍 DemoClassBasedHandler","kind":"service","lifetime":"singleton","module":"pet_store_demo_app.cbr","parent":"group_cbr","original_parent":"group_cbr","group":"cbr","factory_name":null},{"id":"pet_store_demo_app_factories_SearchClient","label":"🏭 SearchClient","kind":"factory","lifetime":"singleton","module":"pet_store_demo_app.factories","parent":"group_factories","original_parent":"group_factories","group":"factories","factory_name":"make_search_client"},{"id":"pet_store_demo_app_fastapi_services_AuthService","label":"🐍 AuthService","kind":"service","lifetime":"scoped","module":"pet_store_demo_app.fastapi_services","parent":"group_fastapi_services","original_parent":"group_fastapi_services","group":"fastapi_services","factory_name":null},{"id":"pet_store_demo_app_services_adoption_AdoptionService","label":"🐍 AdoptionService","kind":"service","lifetime":"scoped","module":"pet_store_demo_app.services.adoption","parent":"group_services_adoption","original_parent":"group_services_adoption","group":"services.adoption","factory_name":null},{"id":"pet_store_demo_app_services_audit_AuditService","label":"🐍 AuditService","kind":"service","lifetime":"singleton","module":"pet_store_demo_app.services.audit","parent":"group_services_audit","original_parent":"group_services_audit","group":"services.audit","factory_name":null},{"id":"pet_store_demo_app_services_infra_MetricsClient","label":"🐍 MetricsClient","kind":"service","lifetime":"singleton","module":"pet_store_demo_app.services.infra","parent":"group_services_infra","original_parent":"group_services_infra","group":"services.infra","factory_name":null},{"id":"pet_store_demo_app_services_infra_RedisConnection","label":"🐍 RedisConnection","kind":"service","lifetime":"singleton","module":"pet_store_demo_app.services.infra","parent":"group_services_infra","original_parent":"group_services_infra","group":"services.infra","factory_name":null},{"id":"pet_store_demo_app_services_infra_ShelterStore","label":"🐍 ShelterStore","kind":"service","lifetime":"singleton","module":"pet_store_demo_app.services.infra","parent":"group_services_infra","original_parent":"group_services_infra","group":"services.infra","factory_name":null},{"id":"pet_store_demo_app_services_owners_OwnerService","label":"🐍 OwnerService","kind":"service","lifetime":"scoped","module":"pet_store_demo_app.services.owners","parent":"group_services_owners","original_parent":"group_services_owners","group":"services.owners","factory_name":null},{"id":"pet_store_demo_app_services_pets_PetCatalogService","label":"🐍 PetCatalogService","kind":"service","lifetime":"singleton","module":"pet_store_demo_app.services.pets","parent":"group_services_pets","original_parent":"group_services_pets","group":"services.pets","factory_name":null},{"id":"pet_store_demo_app_services_session_SQLAlchemySession","label":"🐍 SQLAlchemySession","kind":"service","lifetime":"scoped","module":"pet_store_demo_app.services.session","parent":"group_services_session","original_parent":"group_services_session","group":"services.session","factory_name":null},{"id":"starlette_requests_Request","label":"🏭 Request","kind":"factory","lifetime":"scoped","module":"wireup.integration.starlette","parent":"group_wireup_integration_starlette","original_parent":"group_wireup_integration_starlette","group":"wireup.integration.starlette","factory_name":"request_factory"},{"id":"starlette_websockets_WebSocket","label":"🏭 WebSocket","kind":"factory","lifetime":"scoped","module":"wireup.integration.starlette","parent":"group_wireup_integration_starlette","original_parent":"group_wireup_integration_starlette","group":"wireup.integration.starlette","factory_name":"websocket_factory"},{"id":"wireup_integration_starlette_WireupTask","label":"🏭 WireupTask","kind":"factory","lifetime":"singleton","module":"wireup.integration.starlette","parent":"group_wireup_integration_starlette","original_parent":"group_wireup_integration_starlette","group":"wireup.integration.starlette","factory_name":"wireup_task_factory"},{"id":"wireup_ioc_container_async_container_AsyncContainer","label":"🏭 AsyncContainer","kind":"factory","lifetime":"singleton","module":"wireup.ioc.container","parent":"group_wireup_ioc_container","original_parent":"group_wireup_ioc_container","group":"wireup.ioc.container","factory_name":"_container_factory"}],"edges":[{"id":"edge_0","source":"config_auth","target":"pet_store_demo_app_fastapi_services_AuthService","label":"default_actor","kind":"dependency"},{"id":"edge_1","source":"config_env","target":"pet_store_demo_app_services_audit_AuditService","label":"event_topic","kind":"dependency"},{"id":"edge_2","source":"config_env","target":"pet_store_demo_app_services_pets_PetCatalogService","label":"featured_tag","kind":"dependency"},{"id":"edge_3","source":"config_infra","target":"pet_store_demo_app_services_infra_MetricsClient","label":"endpoint","kind":"dependency"},{"id":"edge_4","source":"config_infra","target":"pet_store_demo_app_services_infra_RedisConnection","label":"dsn","kind":"dependency"},{"id":"edge_5","source":"config_infra","target":"pet_store_demo_app_services_session_SQLAlchemySession","label":"database_url","kind":"dependency"},{"id":"edge_6","source":"config_infra","target":"pet_store_demo_app_services_session_SQLAlchemySession","label":"schema","kind":"dependency"},{"id":"edge_7","source":"config_messaging","target":"pet_store_demo_app_services_adoption_AdoptionService","label":"adoption_queue","kind":"dependency"},{"id":"edge_8","source":"config_messaging","target":"pet_store_demo_app_services_audit_AuditService","label":"event_topic","kind":"dependency"},{"id":"edge_9","source":"config_pets","target":"pet_store_demo_app_services_adoption_AdoptionService","label":"adoption_queue","kind":"dependency"},{"id":"edge_10","source":"config_pets","target":"pet_store_demo_app_services_pets_PetCatalogService","label":"featured_tag","kind":"dependency"},{"id":"edge_11","source":"config_pets","target":"pet_store_demo_app_services_pets_PetCatalogService","label":"shelter_name","kind":"dependency"},{"id":"edge_12","source":"config_services","target":"pet_store_demo_app_factories_SearchClient","label":"search_url","kind":"dependency"},{"id":"edge_13","source":"pet_store_demo_app_cbr_DemoClassBasedHandler","target":"consumer_GET_class_based_overview","label":"handler","kind":"dependency"},{"id":"edge_14","source":"pet_store_demo_app_factories_SearchClient","target":"pet_store_demo_app_services_pets_PetCatalogService","label":"search","kind":"dependency"},{"id":"edge_15","source":"pet_store_demo_app_fastapi_services_AuthService","target":"consumer_GET_whoami","label":"service","kind":"dependency"},{"id":"edge_16","source":"pet_store_demo_app_services_adoption_AdoptionService","target":"consumer_GET_class_based_overview","label":"adoption_service","kind":"dependency"},{"id":"edge_17","source":"pet_store_demo_app_services_adoption_AdoptionService","target":"consumer_POST_pets_pet_id_adopt","label":"service","kind":"dependency"},{"id":"edge_18","source":"pet_store_demo_app_services_audit_AuditService","target":"pet_store_demo_app_cbr_DemoClassBasedHandler","label":"audit_service","kind":"dependency"},{"id":"edge_19","source":"pet_store_demo_app_services_audit_AuditService","target":"pet_store_demo_app_services_adoption_AdoptionService","label":"audit","kind":"dependency"},{"id":"edge_20","source":"pet_store_demo_app_services_audit_AuditService","target":"pet_store_demo_app_services_owners_OwnerService","label":"audit","kind":"dependency"},{"id":"edge_21","source":"pet_store_demo_app_services_audit_AuditService","target":"pet_store_demo_app_services_pets_PetCatalogService","label":"audit","kind":"dependency"},{"id":"edge_22","source":"pet_store_demo_app_services_infra_MetricsClient","target":"pet_store_demo_app_services_infra_ShelterStore","label":"metrics","kind":"dependency"},{"id":"edge_23","source":"pet_store_demo_app_services_infra_RedisConnection","target":"pet_store_demo_app_services_infra_ShelterStore","label":"redis","kind":"dependency"},{"id":"edge_24","source":"pet_store_demo_app_services_infra_ShelterStore","target":"pet_store_demo_app_services_adoption_AdoptionService","label":"shelter_store","kind":"dependency"},{"id":"edge_25","source":"pet_store_demo_app_services_infra_ShelterStore","target":"pet_store_demo_app_services_audit_AuditService","label":"shelter_store","kind":"dependency"},{"id":"edge_26","source":"pet_store_demo_app_services_infra_ShelterStore","target":"pet_store_demo_app_services_owners_OwnerService","label":"shelter_store","kind":"dependency"},{"id":"edge_27","source":"pet_store_demo_app_services_infra_ShelterStore","target":"pet_store_demo_app_services_pets_PetCatalogService","label":"shelter_store","kind":"dependency"},{"id":"edge_28","source":"pet_store_demo_app_services_owners_OwnerService","target":"consumer_GET_owners_owner_id","label":"service","kind":"dependency"},{"id":"edge_29","source":"pet_store_demo_app_services_pets_PetCatalogService","target":"consumer_GET_pets","label":"service","kind":"dependency"},{"id":"edge_30","source":"pet_store_demo_app_services_pets_PetCatalogService","target":"consumer_GET_pets_pet_id","label":"service","kind":"dependency"},{"id":"edge_31","source":"pet_store_demo_app_services_pets_PetCatalogService","target":"consumer_pet_store_demo_app_main_list_featured_pets","label":"catalog","kind":"dependency"},{"id":"edge_32","source":"pet_store_demo_app_services_pets_PetCatalogService","target":"pet_store_demo_app_services_adoption_AdoptionService","label":"catalog","kind":"dependency"},{"id":"edge_33","source":"pet_store_demo_app_services_session_SQLAlchemySession","target":"consumer_GET_class_based_overview","label":"session","kind":"dependency"},{"id":"edge_34","source":"pet_store_demo_app_services_session_SQLAlchemySession","target":"consumer_GET_db_session","label":"service","kind":"dependency"},{"id":"edge_35","source":"pet_store_demo_app_services_session_SQLAlchemySession","target":"pet_store_demo_app_fastapi_services_AuthService","label":"session","kind":"dependency"},{"id":"edge_36","source":"pet_store_demo_app_services_session_SQLAlchemySession","target":"pet_store_demo_app_services_adoption_AdoptionService","label":"session","kind":"dependency"},{"id":"edge_37","source":"pet_store_demo_app_services_session_SQLAlchemySession","target":"pet_store_demo_app_services_owners_OwnerService","label":"session","kind":"dependency"},{"id":"edge_38","source":"starlette_requests_Request","target":"pet_store_demo_app_fastapi_services_AuthService","label":"request","kind":"dependency"}]}</script>
+    <script src="https://cdn.jsdelivr.net/npm/cytoscape@3.30.2/dist/cytoscape.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/dagre@0.8.5/dist/dagre.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/cytoscape-dagre@2.5.0/cytoscape-dagre.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/elkjs@0.10.0/lib/elk.bundled.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/cytoscape-elk@2.3.0/dist/cytoscape-elk.js"></script>
+    <script>
+        const VIEWPORT_PADDING = 100;
+        const GRID_SIZE = 24;
+        if (typeof cytoscapeDagre === "function") {
+            cytoscape.use(cytoscapeDagre);
+        }
+        if (typeof cytoscapeElk === "function") {
+            cytoscape.use(cytoscapeElk);
+        }
+        const graphData = JSON.parse(document.getElementById("wireup-graph-data").textContent);
+        const legendList = document.getElementById("legend-list");
+        const search = document.getElementById("search");
+        const layoutMode = document.getElementById("layout-mode");
+        const toggleConfig = document.getElementById("toggle-config");
+        const toggleEdgeLabels = document.getElementById("toggle-edge-labels");
+        const toggleModules = document.getElementById("toggle-modules");
+        const toggleEmptyGroups = document.getElementById("toggle-empty-groups");
+        const controlsToggleButton = document.getElementById("controls-toggle");
+        const controlsPanel = document.getElementById("controls-panel");
+        const resetLayoutButton = document.getElementById("reset-layout");
+        const resetViewportButton = document.getElementById("reset-viewport");
+        const exportPngButton = document.getElementById("export-png");
+        const themeToggleButton = document.getElementById("theme-toggle");
+        const availableLayouts = new Set(["breadthfirst", "grid", "circle", "concentric", "dagre", "elk"]);
+        const hasDagreLayout = typeof cytoscape("layout", "dagre") === "function";
+        const hasElkLayout = typeof cytoscape("layout", "elk") === "function";
+
+        if (!availableLayouts.has(layoutMode.value) && layoutMode.options.length > 0) {
+            layoutMode.value = layoutMode.options[0].value;
+        }
+
+        function getInitialLayoutName() {
+            if (hasDagreLayout) {
+                return "dagre";
+            }
+            if (hasElkLayout) {
+                return "elk";
+            }
+            return "breadthfirst";
+        }
+
+        function buildLegendItem(className, title, description, showDescription = false) {
+            const escapedDescription = escapeHtml(description);
+            const titleMarkup = showDescription
+                ? `<span class="legend-title">${title}</span>`
+                : (
+                    `<span class="legend-title" data-tooltip="${escapedDescription}" title="${escapedDescription}">` +
+                    `${title}</span>`
+                );
+            const descriptionMarkup = showDescription
+                ? `<span class="legend-description">${description}</span>`
+                : "";
+
+            return (
+                `<span class="legend-pill ${className}">` +
+                `<span class="legend-copy">` +
+                titleMarkup +
+                descriptionMarkup +
+                `</span>` +
+                `</span>`
+            );
+        }
+
+        function getConsumerLegendKinds() {
+            const consumerNodes = graphData.nodes.filter((node) => node.kind === "consumer");
+            const hasRoute = consumerNodes.some((node) => String(node.label || "").startsWith("🌐 "));
+            const hasFunction = consumerNodes.some((node) => String(node.label || "").startsWith("ƒ "));
+
+            return { hasRoute, hasFunction };
+        }
+
+        function renderLegend() {
+            const staticLegend = [
+                buildLegendItem("lifetime singleton", "Singleton", "Shared across the whole container."),
+                buildLegendItem("lifetime scoped", "Scoped", "Created once per active request or scope."),
+                buildLegendItem("lifetime transient", "Transient", "Created fresh for each injection."),
+            ];
+            const kinds = new Set(graphData.nodes.map((node) => node.kind));
+            const dynamicLegend = [];
+            const consumerKinds = getConsumerLegendKinds();
+
+            if (kinds.has("consumer") && consumerKinds.hasFunction) {
+                dynamicLegend.push(buildLegendItem("consumer", "ƒ Function", "Injected callables discovered outside routes."));
+            }
+            if (kinds.has("consumer") && consumerKinds.hasRoute) {
+                dynamicLegend.push(buildLegendItem("consumer", "🌐 Route", "Framework entrypoints that request dependencies."));
+            }
+            if (kinds.has("service")) {
+                dynamicLegend.push(
+                    buildLegendItem("service", "🐍 Class injectable", "Registered classes resolved from the container.")
+                );
+            }
+            if (kinds.has("config")) {
+                dynamicLegend.push(
+                    buildLegendItem("config", "⚙️ Configuration", "Config values injected into services or functions.")
+                );
+            }
+            if (kinds.has("factory")) {
+                dynamicLegend.push(
+                    buildLegendItem("factory", "🏭 Factory", "Factory providers that create dependency instances.")
+                );
+            }
+
+            legendList.innerHTML = `${dynamicLegend.join("")}${staticLegend.join("")}`;
+        }
+
+        function getBootLayoutConfig() {
+            const initialLayout = getInitialLayoutName();
+
+            if (initialLayout === "dagre") {
+                return {
+                    name: "dagre",
+                    rankDir: "LR",
+                    padding: VIEWPORT_PADDING,
+                    spacingFactor: 1.1,
+                    nodeSep: 40,
+                    rankSep: 84
+                };
+            }
+
+            if (initialLayout === "elk") {
+                return {
+                    name: "elk",
+                    fit: true,
+                    animate: false,
+                    padding: VIEWPORT_PADDING,
+                    elk: {
+                        algorithm: "layered",
+                        "elk.direction": "RIGHT",
+                        "elk.layered.spacing.nodeNodeBetweenLayers": "90",
+                        "elk.spacing.nodeNode": "36",
+                        "elk.edgeRouting": "ORTHOGONAL"
+                    }
+                };
+            }
+
+            return {
+                name: "breadthfirst",
+                directed: true,
+                padding: VIEWPORT_PADDING,
+                spacingFactor: 1.15,
+                animate: false,
+                fit: true
+            };
+        }
+
+        const nodeParentById = Object.fromEntries(
+            graphData.nodes.map((node) => [node.id, node.original_parent || node.parent || null])
+        );
+        const aggregateEdges = (() => {
+            const groupedEdges = new Map();
+
+            graphData.edges.forEach((edge) => {
+                const sourceParent = nodeParentById[edge.source];
+                const targetParent = nodeParentById[edge.target];
+                if (!sourceParent || !targetParent || sourceParent === targetParent) {
+                    return;
+                }
+
+                const key = `${sourceParent}->${targetParent}`;
+                if (groupedEdges.has(key)) {
+                    return;
+                }
+
+                groupedEdges.set(key, {
+                    id: `aggregate_${groupedEdges.size}`,
+                    source: sourceParent,
+                    target: targetParent,
+                    label: "",
+                    kind: "aggregate"
+                });
+            });
+
+            return [...groupedEdges.values()];
+        })();
+        const elements = [
+            ...graphData.groups.map((group) => ({ data: group })),
+            ...graphData.nodes.map((node) => ({ data: node })),
+            ...graphData.edges.map((edge) => ({ data: edge })),
+            ...aggregateEdges.map((edge) => ({ data: edge }))
+        ];
+
+        const cy = cytoscape({
+            container: document.getElementById("cy"),
+            elements,
+            layout: getBootLayoutConfig(),
+            wheelSensitivity: 0.15,
+            style: []
+        });
+
+        const details = document.getElementById("details");
+        const cyContainer = document.getElementById("cy");
+
+        let activeNodeId = null;
+
+        function getStoragePrefix() {
+            return `wireup:positions:${document.title || "wireup-graph"}`;
+        }
+
+        function getStorageKey() {
+            return `${getStoragePrefix()}:${layoutMode.value}:${toggleModules.checked ? "modules" : "flat"}`;
+        }
+
+        function getThemeStorageKey() {
+            return `wireup:theme:${document.title || "wireup-graph"}`;
+        }
+
+        function getLayoutStorageKey() {
+            return `wireup:layout:${document.title || "wireup-graph"}`;
+        }
+
+        function readCssVar(name) {
+            return getComputedStyle(document.body).getPropertyValue(name).trim();
+        }
+
+        function applyTheme(theme) {
+            document.documentElement.setAttribute("data-theme", theme);
+            window.localStorage.setItem(getThemeStorageKey(), theme);
+            applyCytoscapeTheme();
+        }
+
+        function setControlsOpen(isOpen) {
+            controlsPanel.hidden = !isOpen;
+            controlsToggleButton.setAttribute("aria-expanded", isOpen ? "true" : "false");
+        }
+
+        function applyCytoscapeTheme() {
+            const ink = readCssVar("--node-text");
+            const lineStrong = readCssVar("--line-strong");
+            const edge = readCssVar("--edge");
+            const edgeStrong = readCssVar("--edge-strong");
+            const service = readCssVar("--service");
+            const factory = readCssVar("--factory");
+            const consumer = readCssVar("--consumer");
+            const config = readCssVar("--config");
+            const group = readCssVar("--group");
+            const accent = readCssVar("--accent");
+            const dependencyHighlight = "#36d2ff";
+            const dependantHighlight = "#ffb02e";
+            const edgeLabelBackground = (
+                document.documentElement.getAttribute("data-theme") === "light" ? "#ffffff" : "#1b2134"
+            );
+
+            cy.style([
+                {
+                    selector: "node",
+                    style: {
+                        "label": "data(label)",
+                        "text-wrap": "wrap",
+                        "text-max-width": 240,
+                        "font-family": "Inter, Segoe UI, sans-serif",
+                        "font-size": 13,
+                        "text-valign": "center",
+                        "text-halign": "center",
+                        "border-width": 1.2,
+                        "border-style": "solid",
+                        "border-color": lineStrong,
+                        "color": ink
+                    }
+                },
+                {
+                    selector: 'node[lifetime = "scoped"]',
+                    style: {
+                        "border-style": "dashed"
+                    }
+                },
+                {
+                    selector: 'node[lifetime = "transient"]',
+                    style: {
+                        "border-style": "dotted"
+                    }
+                },
+                {
+                    selector: 'node[kind = "service"]',
+                    style: {
+                        "shape": "round-rectangle",
+                        "width": 220,
+                        "height": 58,
+                        "background-color": service
+                    }
+                },
+                {
+                    selector: 'node[kind = "factory"]',
+                    style: {
+                        "shape": "round-rectangle",
+                        "width": 228,
+                        "height": 64,
+                        "background-color": factory
+                    }
+                },
+                {
+                    selector: 'node[kind = "consumer"]',
+                    style: {
+                        "shape": "round-rectangle",
+                        "width": 260,
+                        "height": 58,
+                        "background-color": consumer
+                    }
+                },
+                {
+                    selector: 'node[kind = "config"]',
+                    style: {
+                        "shape": "round-rectangle",
+                        "width": 118,
+                        "height": 44,
+                        "background-color": config
+                    }
+                },
+                {
+                    selector: 'node[kind = "group"]',
+                    style: {
+                        "shape": "round-rectangle",
+                        "padding": "26px",
+                        "font-weight": 700,
+                        "font-size": 15,
+                        "text-valign": "top",
+                        "text-halign": "center",
+                        "background-color": group,
+                        "border-style": "solid",
+                        "border-color": lineStrong,
+                        "color": ink
+                    }
+                },
+                {
+                    selector: "$node > node",
+                    style: {
+                        "text-margin-y": -12
+                    }
+                },
+                {
+                    selector: "edge",
+                    style: {
+                        "curve-style": "bezier",
+                        "width": 1.7,
+                        "line-color": edge,
+                        "target-arrow-color": edge,
+                        "target-arrow-shape": "triangle",
+                        "arrow-scale": 0.85,
+                        "label": "data(display_label)",
+                        "font-size": 10,
+                        "text-background-color": edgeLabelBackground,
+                        "text-background-opacity": 0.94,
+                        "text-background-padding": 3,
+                        "color": ink
+                    }
+                },
+                {
+                    selector: 'edge[kind = "aggregate"]',
+                    style: {
+                        "width": 2.2,
+                        "line-color": edgeStrong,
+                        "target-arrow-color": edgeStrong
+                    }
+                },
+                {
+                    selector: ".dimmed",
+                    style: {
+                        "opacity": 0.1
+                    }
+                },
+                {
+                    selector: ".highlight-selected",
+                    style: {
+                        "border-color": accent,
+                        "border-width": 2.4,
+                        "opacity": 1
+                    }
+                },
+                {
+                    selector: ".highlight-dependency",
+                    style: {
+                        "border-color": dependencyHighlight,
+                        "opacity": 1
+                    }
+                },
+                {
+                    selector: ".highlight-dependant",
+                    style: {
+                        "border-color": dependantHighlight,
+                        "opacity": 1
+                    }
+                },
+                {
+                    selector: ".hidden",
+                    style: {
+                        "display": "none"
+                    }
+                }
+            ]).update();
+        }
+
+        function savePositions() {
+            const positions = {};
+            cy.nodes().forEach((node) => {
+                positions[node.id()] = node.position();
+            });
+            window.localStorage.setItem(getStorageKey(), JSON.stringify(positions));
+        }
+
+        function snapValue(value) {
+            return Math.round(value / GRID_SIZE) * GRID_SIZE;
+        }
+
+        function snapPosition(position) {
+            return {
+                x: snapValue(position.x),
+                y: snapValue(position.y)
+            };
+        }
+
+        function snapNodeToGrid(node) {
+            node.position(snapPosition(node.position()));
+        }
+
+        function clearStoredPositions() {
+            const prefix = `${getStoragePrefix()}:`;
+            const keysToRemove = [];
+
+            for (let index = 0; index < window.localStorage.length; index += 1) {
+                const key = window.localStorage.key(index);
+                if (key && key.startsWith(prefix)) {
+                    keysToRemove.push(key);
+                }
+            }
+
+            keysToRemove.forEach((key) => {
+                window.localStorage.removeItem(key);
+            });
+        }
+
+        function restorePositions() {
+            const raw = window.localStorage.getItem(getStorageKey());
+            if (!raw) {
+                return false;
+            }
+
+            try {
+                const positions = JSON.parse(raw);
+                cy.batch(() => {
+                    cy.nodes().forEach((node) => {
+                        const position = positions[node.id()];
+                        if (position && typeof position.x === "number" && typeof position.y === "number") {
+                            node.position(snapPosition(position));
+                        }
+                    });
+                });
+                cy.fit(cy.elements(":visible"), VIEWPORT_PADDING);
+                return true;
+            } catch {
+                window.localStorage.removeItem(getStorageKey());
+                return false;
+            }
+        }
+
+        function getLayoutConfig() {
+            if (layoutMode.value === "dagre" && hasDagreLayout) {
+                return {
+                    name: "dagre",
+                    rankDir: "LR",
+                    padding: VIEWPORT_PADDING,
+                    spacingFactor: 1.1,
+                    nodeSep: 40,
+                    rankSep: 84,
+                    animate: false,
+                    fit: true
+                };
+            }
+
+            if (layoutMode.value === "elk" && hasElkLayout) {
+                return {
+                    name: "elk",
+                    fit: true,
+                    animate: false,
+                    padding: VIEWPORT_PADDING,
+                    elk: {
+                        algorithm: "layered",
+                        "elk.direction": "RIGHT",
+                        "elk.layered.spacing.nodeNodeBetweenLayers": "90",
+                        "elk.spacing.nodeNode": "36",
+                        "elk.edgeRouting": "ORTHOGONAL"
+                    }
+                };
+            }
+
+            if (layoutMode.value === "grid") {
+                return {
+                    name: "grid",
+                    padding: VIEWPORT_PADDING,
+                    avoidOverlap: true,
+                    fit: true,
+                    animate: false
+                };
+            }
+
+            if (layoutMode.value === "circle") {
+                return {
+                    name: "circle",
+                    padding: VIEWPORT_PADDING,
+                    fit: true,
+                    animate: false
+                };
+            }
+
+            if (layoutMode.value === "concentric") {
+                return {
+                    name: "concentric",
+                    padding: VIEWPORT_PADDING,
+                    fit: true,
+                    animate: false,
+                    avoidOverlap: true,
+                    minNodeSpacing: 28
+                };
+            }
+
+            return {
+                name: "breadthfirst",
+                directed: true,
+                padding: VIEWPORT_PADDING,
+                spacingFactor: 1.15,
+                animate: false,
+                fit: true
+            };
+        }
+
+        function rerunLayout() {
+            window.localStorage.setItem(getLayoutStorageKey(), layoutMode.value);
+            const layout = cy.layout(getLayoutConfig());
+            layout.one("layoutstop", () => {
+                cy.batch(() => {
+                    cy.nodes().forEach((node) => {
+                        if (node.data("kind") !== "group") {
+                            snapNodeToGrid(node);
+                        }
+                    });
+                });
+                savePositions();
+            });
+            layout.run();
+        }
+
+        function isAggregateOverview() {
+            return toggleModules.checked && activeNodeId === null;
+        }
+
+        function applyModuleOrganization() {
+            cy.batch(() => {
+                cy.nodes().forEach((node) => {
+                    if (node.data("kind") === "group") {
+                        return;
+                    }
+
+                    const originalParent = node.data("original_parent") || null;
+                    const currentParent = node.parent().length ? node.parent().id() : null;
+                    if (toggleModules.checked) {
+                        if (originalParent && currentParent !== originalParent) {
+                            node.move({ parent: originalParent });
+                        }
+                    } else if (currentParent !== null) {
+                        node.move({ parent: null });
+                    }
+                });
+            });
+        }
+
+        function applyGroupVisibility() {
+            if (!toggleModules.checked) {
+                cy.nodes('[kind = "group"]').addClass("hidden");
+                return;
+            }
+
+            cy.nodes('[kind = "group"]').removeClass("hidden");
+            if (toggleEmptyGroups.checked) {
+                return;
+            }
+
+            cy.nodes('[kind = "group"]').forEach((group) => {
+                if (isAggregateOverview()) {
+                    if (group.connectedEdges().filter((edge) => !edge.hasClass("hidden")).length === 0) {
+                        group.addClass("hidden");
+                    }
+                    return;
+                }
+
+                const visibleChildren = group.children().filter((child) => !child.hasClass("hidden"));
+                const usedChildren = visibleChildren.filter((child) => {
+                    return child.connectedEdges().filter((edge) => !edge.hasClass("hidden")).length > 0;
+                });
+                if (usedChildren.length === 0) {
+                    group.addClass("hidden");
+                }
+            });
+        }
+
+        function pruneUnusedNodes() {
+            if (toggleEmptyGroups.checked || isAggregateOverview()) {
+                return;
+            }
+
+            cy.nodes().forEach((node) => {
+                if (node.data("kind") === "group" || node.hasClass("hidden")) {
+                    return;
+                }
+                if (node.connectedEdges().filter((edge) => !edge.hasClass("hidden")).length === 0) {
+                    node.addClass("hidden");
+                }
+            });
+        }
+
+        function applyVisibility() {
+            cy.elements().removeClass("hidden");
+            applyModuleOrganization();
+
+            cy.nodes().forEach((node) => {
+                if (node.data("kind") === "config" && !toggleConfig.checked) {
+                    node.addClass("hidden");
+                }
+            });
+
+            cy.edges().forEach((edge) => {
+                const isAggregate = edge.data("kind") === "aggregate";
+                if (
+                    isAggregate !== isAggregateOverview() ||
+                    edge.source().hasClass("hidden") ||
+                    edge.target().hasClass("hidden")
+                ) {
+                    edge.addClass("hidden");
+                }
+            });
+
+            pruneUnusedNodes();
+            cy.edges().forEach((edge) => {
+                const isAggregate = edge.data("kind") === "aggregate";
+                if (
+                    isAggregate !== isAggregateOverview() ||
+                    edge.source().hasClass("hidden") ||
+                    edge.target().hasClass("hidden")
+                ) {
+                    edge.addClass("hidden");
+                }
+                edge.data(
+                    "display_label",
+                    toggleEdgeLabels.checked && edge.data("kind") === "dependency" ? edge.data("label") : ""
+                );
+            });
+
+            cy.nodes('[kind = "group"]').removeClass("dimmed");
+            applyGroupVisibility();
+
+            const query = search.value.trim().toLowerCase();
+            cy.elements().removeClass("dimmed");
+            if (!query) {
+                return;
+            }
+
+            const hits = cy.nodes().filter((node) => {
+                return !node.hasClass("hidden") && (
+                    String(node.data("label") || "").toLowerCase().includes(query) ||
+                    String(node.data("module") || "").toLowerCase().includes(query)
+                );
+            });
+
+            cy.elements().addClass("dimmed");
+            hits.removeClass("dimmed");
+            hits.connectedEdges().removeClass("dimmed");
+            hits.connectedEdges().connectedNodes().removeClass("dimmed");
+            cy.nodes('[kind = "group"]').removeClass("dimmed");
+            applyGroupVisibility();
+        }
+
+        function showNeighborhood(node) {
+            activeNodeId = node.id();
+            applyVisibility();
+            cy.elements().removeClass("dimmed highlight-selected highlight-dependency highlight-dependant");
+            cy.elements().addClass("dimmed");
+            cy.nodes('[kind = "group"]').removeClass("dimmed");
+
+            const dependencies = node.predecessors();
+            const dependants = node.successors();
+            const dependencyNodes = dependencies.filter("node");
+            const dependencyEdges = dependencies.filter("edge");
+            const dependantNodes = dependants.filter("node");
+            const dependantEdges = dependants.filter("edge");
+
+            node.removeClass("dimmed");
+            node.addClass("highlight-selected");
+            dependencyNodes.removeClass("dimmed");
+            dependencyNodes.addClass("highlight-dependency");
+            dependencyEdges.removeClass("dimmed");
+            dependantNodes.removeClass("dimmed");
+            dependantNodes.addClass("highlight-dependant");
+            dependantEdges.removeClass("dimmed");
+
+            renderDetails(node, {
+                modeLabel: null,
+                dependencies: node.incomers("node"),
+                dependants: node.outgoers("node"),
+            });
+        }
+
+        function showDependencyPaths(node) {
+            activeNodeId = node.id();
+            applyVisibility();
+            cy.elements().removeClass("dimmed highlight-selected highlight-dependency highlight-dependant");
+            cy.elements().addClass("dimmed");
+            cy.nodes('[kind = "group"]').removeClass("dimmed");
+
+            const dependencies = node.predecessors();
+            const dependencyNodes = dependencies.filter("node");
+            const dependencyEdges = dependencies.filter("edge");
+
+            node.removeClass("dimmed");
+            node.addClass("highlight-selected");
+            dependencyNodes.removeClass("dimmed");
+            dependencyNodes.addClass("highlight-dependency");
+            dependencyEdges.removeClass("dimmed");
+
+            renderDetails(node, {
+                modeLabel: "Dependency paths",
+                dependencies: node.incomers("node"),
+                dependants: cy.collection(),
+            });
+        }
+
+        function resetFocus() {
+            activeNodeId = null;
+            cy.elements().removeClass("dimmed highlight-selected highlight-dependency highlight-dependant");
+            applyVisibility();
+            details.innerHTML = `
+        <h2>No node selected</h2>
+        <p class="details-empty">Left click for the full neighborhood. Right click for dependency paths only.</p>
+      `;
+        }
+
+        function getKindDetails(kind) {
+            if (kind === "consumer") {
+                const label = String(arguments[1] || "");
+                if (label.startsWith("🌐 ")) {
+                    return { label: "Route", color: "#ecfccb" };
+                }
+                if (label.startsWith("ƒ ")) {
+                    return { label: "Function", color: "#ecfccb" };
+                }
+                return { label: "Function", color: "#ecfccb" };
+            }
+            if (kind === "service") return { label: "Class injectable", color: "#fff7ed" };
+            if (kind === "factory") return { label: "Factory", color: "#eef6ff" };
+            if (kind === "config") return { label: "Configuration", color: "#f6f2ff" };
+            if (kind === "group") return { label: "Module group", color: "#fef3c7" };
+            return { label: kind || "Unknown", color: "#e5e7eb" };
+        }
+
+        function escapeHtml(value) {
+            return String(value)
+                .replace(/&/g, "&amp;")
+                .replace(/</g, "&lt;")
+                .replace(/>/g, "&gt;")
+                .replace(/"/g, "&quot;")
+                .replace(/'/g, "&#39;");
+        }
+
+        function formatLifetime(value) {
+            if (!value) return null;
+            return value.charAt(0).toUpperCase() + value.slice(1);
+        }
+
+        function renderNeighborPills(nodes) {
+            const uniqueNodes = [];
+            const seen = new Set();
+            nodes.forEach((item) => {
+                if (item.isNode && item.isNode() && !seen.has(item.id())) {
+                    seen.add(item.id());
+                    uniqueNodes.push(item);
+                }
+            });
+
+            if (!uniqueNodes.length) {
+                return '<span class="details-pill empty">None</span>';
+            }
+
+            return uniqueNodes
+                .sort((left, right) => String(left.data("label")).localeCompare(String(right.data("label"))))
+                .map((item) => `
+          <button class="details-pill" type="button" data-node-id="${escapeHtml(item.id())}">
+            <span>${escapeHtml(String(item.data("label")).replace(/\n/g, " "))}</span>
+          </button>
+        `)
+                .join("");
+        }
+
+        function renderDetails(node, { modeLabel, dependencies, dependants }) {
+            const kindInfo = getKindDetails(node.data("kind"), node.data("label"));
+            const rows = [
+                `<dt>Kind</dt><dd><span class="details-value">` +
+                `<span class="details-kind-box" style="background:${kindInfo.color};"></span>` +
+                `<span>${kindInfo.label}</span></span></dd>`
+            ];
+
+            const lifetime = formatLifetime(node.data("lifetime"));
+            if (lifetime) {
+                rows.push(`<dt>Lifetime</dt><dd>${escapeHtml(lifetime)}</dd>`);
+            }
+            if (node.data("module")) {
+                rows.push(`<dt>Module</dt><dd class="details-meta-code">${escapeHtml(node.data("module"))}</dd>`);
+            }
+            if (node.data("factory_name")) {
+                rows.push(`<dt>Factory</dt><dd class="details-meta-code">${escapeHtml(node.data("factory_name"))}</dd>`);
+            }
+            if (modeLabel) {
+                rows.push(`<dt>Mode</dt><dd>${escapeHtml(modeLabel)}</dd>`);
+            }
+
+            const dependencyPills = renderNeighborPills(dependencies);
+            const dependantPills = renderNeighborPills(dependants);
+
+            details.innerHTML = `
+        <h2>${escapeHtml(String(node.data("label")).replace(/\n/g, " "))}</h2>
+        <div class="details-section">
+          <div class="details-section-title">Details</div>
+          <dl>${rows.join("")}</dl>
+        </div>
+        <div class="details-section">
+          <div class="details-section-title">Depends on</div>
+          <div class="details-pills">${dependencyPills}</div>
+        </div>
+        <div class="details-section">
+          <div class="details-section-title">Used by</div>
+          <div class="details-pills">${dependantPills}</div>
+        </div>
+        <p class="details-subtitle">Select any related node below to jump across the graph.</p>
+      `;
+        }
+
+        [toggleConfig, toggleEdgeLabels, toggleEmptyGroups].forEach((checkbox) => {
+            checkbox.addEventListener("change", applyVisibility);
+        });
+
+        layoutMode.addEventListener("change", () => {
+            clearStoredPositions();
+            rerunLayout();
+        });
+
+        toggleModules.addEventListener("change", () => {
+            resetFocus();
+            if (!restorePositions()) {
+                rerunLayout();
+            }
+        });
+
+        search.addEventListener("input", applyVisibility);
+        resetViewportButton.addEventListener("click", () => {
+            cy.fit(cy.elements(":visible"), VIEWPORT_PADDING);
+            setControlsOpen(false);
+        });
+        exportPngButton.addEventListener("click", () => {
+            const png = cy.png({ full: true, scale: 2, bg: readCssVar("--bg-canvas") });
+            const link = document.createElement("a");
+            link.href = png;
+            link.download = "wireup-graph.png";
+            link.click();
+            setControlsOpen(false);
+        });
+        themeToggleButton.addEventListener("click", () => {
+            const nextTheme = document.documentElement.getAttribute("data-theme") === "dark" ? "light" : "dark";
+            applyTheme(nextTheme);
+            setControlsOpen(false);
+        });
+        resetLayoutButton.addEventListener("click", () => {
+            clearStoredPositions();
+            rerunLayout();
+            setControlsOpen(false);
+        });
+        controlsToggleButton.addEventListener("click", () => {
+            setControlsOpen(controlsPanel.hidden);
+        });
+
+        cy.on("tap", "node", (event) => {
+            if (event.target.data("kind") !== "group") {
+                showNeighborhood(event.target);
+            }
+        });
+        cy.on("cxttap", "node", (event) => {
+            if (event.target.data("kind") !== "group") {
+                showDependencyPaths(event.target);
+            }
+        });
+        cy.on("tap", (event) => {
+            if (event.target === cy) {
+                resetFocus();
+            }
+        });
+        details.addEventListener("click", (event) => {
+            const button = event.target.closest("[data-node-id]");
+            if (!button) return;
+            const nextNode = cy.getElementById(button.getAttribute("data-node-id"));
+            if (nextNode && nextNode.length) {
+                showNeighborhood(nextNode);
+            }
+        });
+        cy.on("dragfreeon", "node", (event) => {
+            snapNodeToGrid(event.target);
+            savePositions();
+        });
+        cyContainer.addEventListener("contextmenu", (event) => {
+            event.preventDefault();
+        });
+        document.addEventListener("click", (event) => {
+            if (!controlsPanel.hidden && !event.target.closest(".controls-menu")) {
+                setControlsOpen(false);
+            }
+        });
+
+        const storedTheme = window.localStorage.getItem(getThemeStorageKey());
+        if (storedTheme === "light" || storedTheme === "dark") {
+            document.documentElement.setAttribute("data-theme", storedTheme);
+        }
+        const storedLayout = window.localStorage.getItem(getLayoutStorageKey());
+        if (storedLayout && [...layoutMode.options].some((option) => option.value === storedLayout)) {
+            layoutMode.value = storedLayout;
+        }
+        renderLegend();
+        applyCytoscapeTheme();
+        applyVisibility();
+        if (!restorePositions()) {
+            rerunLayout();
+        }
+    </script>
+</body>
+
+</html>

--- a/readme.md
+++ b/readme.md
@@ -71,6 +71,22 @@ Override dependencies with context managers, keep tests isolated, and restore th
     Full methodology and reproducibility: <a href="https://maldoinc.github.io/wireup/latest/benchmarks/">benchmarks</a>.</i>
 </p>
 
+## Interactive Graph
+
+Turn your container into an interactive dependency graph. Explore routes, functions, services, factories,
+configuration, and scopes in a live page with search, grouping, and dependency tracing.
+
+Learn how it works and explore it on an example pet store app:
+
+<p align="center">
+  <img alt="Wireup interactive dependency graph demo" src="docs/pages/img/pet_store_demo.gif">
+</p>
+
+<p align="center">
+  <a href="https://maldoinc.github.io/wireup/latest/interactive_graph/" target="_blank"><strong>Documentation</strong></a> &middot;
+  <a href="https://maldoinc.github.io/wireup/latest/wireup_graph/pet_store.html" target="_blank"><strong>Live Demo</strong></a>
+</p>
+
 ## Installation
 
 ```bash

--- a/test/integration/flask/test_flask_integration.py
+++ b/test/integration/flask/test_flask_integration.py
@@ -6,7 +6,8 @@ import wireup.integration.flask
 from flask import Flask
 from flask.testing import FlaskClient
 from wireup._annotations import Injected, injectable
-from wireup.integration.flask import get_app_container
+from wireup.integration.flask import GraphEndpointOptions, get_app_container
+from wireup.renderer._consumers import get_consumers
 
 from test.integration.flask import services as flask_integration_services
 from test.integration.flask.bp import bp
@@ -107,3 +108,65 @@ def test_flask_err_cleanup() -> None:
 
     assert dep["created"] is True
     assert dep["cleanup"] is True
+
+
+def test_graph_endpoint_renders_flask_dependency_page() -> None:
+    app = Flask(__name__)
+    app.config["TESTING"] = True
+    app.register_blueprint(bp)
+
+    container = wireup.create_sync_container(
+        injectables=[shared_services, flask_integration_services],
+        config={**app.config, "custom_params": True},
+    )
+    wireup.integration.flask.setup(
+        container,
+        app,
+        add_graph_endpoint=True,
+        graph_endpoint_options=GraphEndpointOptions(base_module="test.integration.flask"),
+    )
+
+    client = app.test_client()
+    res = client.get("/_wireup")
+
+    assert res.status_code == 200
+    assert "text/html" in res.content_type
+    assert "Wireup Graph" in res.text
+    assert "test.integration.flask.bp" in res.text
+    assert "random" in res.text
+    assert "Flask" in res.text
+
+
+def test_flask_views_record_route_metadata() -> None:
+    app = Flask(__name__)
+    app.config["TESTING"] = True
+    app.register_blueprint(bp)
+
+    container = wireup.create_sync_container(
+        injectables=[shared_services, flask_integration_services],
+        config={**app.config, "custom_params": True},
+    )
+    wireup.integration.flask.setup(container, app)
+
+    consumers = {consumer.id: consumer for consumer in get_consumers(container)}
+
+    consumer = consumers["GET /random"]
+    assert consumer.kind == "flask_route"
+    assert consumer.label == "🌐 GET /random"
+    assert consumer.group == "Flask"
+    assert consumer.module == "test.integration.flask.bp"
+
+
+def test_graph_endpoint_setup_called_again_raises() -> None:
+    app = Flask(__name__)
+    app.config["TESTING"] = True
+    app.register_blueprint(bp)
+
+    container = wireup.create_sync_container(
+        injectables=[shared_services, flask_integration_services],
+        config={**app.config, "custom_params": True},
+    )
+
+    wireup.integration.flask.setup(container, app, add_graph_endpoint=True)
+    with pytest.raises(AssertionError):
+        wireup.integration.flask.setup(container, app, add_graph_endpoint=True)

--- a/test/unit/large_mermaid_app/__init__.py
+++ b/test/unit/large_mermaid_app/__init__.py
@@ -1,0 +1,14 @@
+from test.unit.large_mermaid_app.factories import HttpClient, make_http_client
+from test.unit.large_mermaid_app.services.audit import AuditService
+from test.unit.large_mermaid_app.services.kv import KeyValueStore, MetricsClient, RedisConnection
+from test.unit.large_mermaid_app.services.weather import WeatherService
+
+__all__ = [
+    "AuditService",
+    "HttpClient",
+    "KeyValueStore",
+    "MetricsClient",
+    "RedisConnection",
+    "WeatherService",
+    "make_http_client",
+]

--- a/test/unit/large_mermaid_app/factories.py
+++ b/test/unit/large_mermaid_app/factories.py
@@ -1,0 +1,18 @@
+from __future__ import annotations
+
+from typing import Iterator
+
+from typing_extensions import Annotated
+from wireup import Inject, injectable
+
+
+class HttpClient:
+    def __init__(self, base_url: str) -> None:
+        self.base_url = base_url
+
+
+@injectable
+def make_http_client(
+    weather_url: Annotated[str, Inject(config="services.weather.base_url")],
+) -> Iterator[HttpClient]:
+    yield HttpClient(weather_url)

--- a/test/unit/large_mermaid_app/services/__init__.py
+++ b/test/unit/large_mermaid_app/services/__init__.py
@@ -1,0 +1,11 @@
+from test.unit.large_mermaid_app.services.audit import AuditService
+from test.unit.large_mermaid_app.services.kv import KeyValueStore, MetricsClient, RedisConnection
+from test.unit.large_mermaid_app.services.weather import WeatherService
+
+__all__ = [
+    "AuditService",
+    "KeyValueStore",
+    "MetricsClient",
+    "RedisConnection",
+    "WeatherService",
+]

--- a/test/unit/large_mermaid_app/services/audit.py
+++ b/test/unit/large_mermaid_app/services/audit.py
@@ -1,0 +1,20 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from typing_extensions import Annotated
+from wireup import Inject, injectable
+
+if TYPE_CHECKING:
+    from test.unit.large_mermaid_app.services.kv import KeyValueStore
+
+
+@injectable
+class AuditService:
+    def __init__(
+        self,
+        kv_store: KeyValueStore,
+        topic: Annotated[str, Inject(expr="${messaging.kafka.topic_prefix}-${env.name}")],
+    ) -> None:
+        self.kv_store = kv_store
+        self.topic = topic

--- a/test/unit/large_mermaid_app/services/kv.py
+++ b/test/unit/large_mermaid_app/services/kv.py
@@ -1,0 +1,23 @@
+from __future__ import annotations
+
+from typing_extensions import Annotated
+from wireup import Inject, injectable
+
+
+@injectable
+class RedisConnection:
+    def __init__(self, dsn: Annotated[str, Inject(config="infra.redis.url")]) -> None:
+        self.dsn = dsn
+
+
+@injectable
+class MetricsClient:
+    def __init__(self, endpoint: Annotated[str, Inject(config="infra.metrics.endpoint")]) -> None:
+        self.endpoint = endpoint
+
+
+@injectable
+class KeyValueStore:
+    def __init__(self, redis: RedisConnection, metrics: MetricsClient) -> None:
+        self.redis = redis
+        self.metrics = metrics

--- a/test/unit/large_mermaid_app/services/weather.py
+++ b/test/unit/large_mermaid_app/services/weather.py
@@ -1,0 +1,28 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from typing_extensions import Annotated
+from wireup import Inject, injectable
+
+if TYPE_CHECKING:
+    from test.unit.large_mermaid_app.factories import HttpClient
+    from test.unit.large_mermaid_app.services.audit import AuditService
+    from test.unit.large_mermaid_app.services.kv import KeyValueStore
+
+
+@injectable
+class WeatherService:
+    def __init__(
+        self,
+        api_key: Annotated[str, Inject(config="services.weather.api_key")],
+        client: HttpClient,
+        kv_store: KeyValueStore,
+        audit: AuditService,
+        cache_key: Annotated[str, Inject(expr="${env.name}-${services.weather.cache_suffix}")],
+    ) -> None:
+        self.api_key = api_key
+        self.client = client
+        self.kv_store = kv_store
+        self.audit = audit
+        self.cache_key = cache_key

--- a/test/unit/large_mermaid_graph_poc.html
+++ b/test/unit/large_mermaid_graph_poc.html
@@ -1,0 +1,594 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Wireup Graph POC</title>
+  <style>
+    :root {
+      color-scheme: light;
+      --bg: #f3f1ea;
+      --panel: rgba(255, 252, 245, 0.92);
+      --ink: #1f2328;
+      --muted: #5d6470;
+      --line: #d3cdc1;
+      --accent: #b45309;
+      --accent-soft: #f6e3c4;
+      --service: #fff7ed;
+      --factory: #eef6ff;
+      --config: #f6f2ff;
+      --module: #fef3c7;
+      --shadow: 0 14px 40px rgba(60, 48, 24, 0.12);
+    }
+
+    * {
+      box-sizing: border-box;
+    }
+
+    body {
+      margin: 0;
+      font-family: "IBM Plex Sans", "Segoe UI", sans-serif;
+      background:
+        radial-gradient(circle at top left, rgba(180, 83, 9, 0.10), transparent 28%),
+        radial-gradient(circle at right center, rgba(59, 130, 246, 0.08), transparent 24%),
+        linear-gradient(180deg, #f8f5ef 0%, var(--bg) 100%);
+      color: var(--ink);
+    }
+
+    .shell {
+      display: grid;
+      grid-template-columns: 320px 1fr;
+      min-height: 100vh;
+      gap: 20px;
+      padding: 20px;
+    }
+
+    .panel {
+      background: var(--panel);
+      border: 1px solid var(--line);
+      border-radius: 18px;
+      box-shadow: var(--shadow);
+      backdrop-filter: blur(14px);
+    }
+
+    .sidebar {
+      padding: 18px;
+      display: flex;
+      flex-direction: column;
+      gap: 16px;
+    }
+
+    .sidebar h1 {
+      margin: 0;
+      font-size: 1.4rem;
+    }
+
+    .sidebar p {
+      margin: 0;
+      color: var(--muted);
+      line-height: 1.45;
+    }
+
+    .field,
+    .group {
+      display: flex;
+      flex-direction: column;
+      gap: 8px;
+    }
+
+    .field label,
+    .group .label {
+      font-size: 0.82rem;
+      font-weight: 700;
+      text-transform: uppercase;
+      letter-spacing: 0.06em;
+      color: var(--muted);
+    }
+
+    input[type="search"] {
+      width: 100%;
+      border: 1px solid var(--line);
+      background: #fff;
+      border-radius: 12px;
+      padding: 10px 12px;
+      font: inherit;
+      color: inherit;
+    }
+
+    .toggle-list {
+      display: grid;
+      gap: 8px;
+    }
+
+    .toggle {
+      display: flex;
+      align-items: center;
+      gap: 10px;
+      font-size: 0.96rem;
+    }
+
+    .toggle input {
+      accent-color: var(--accent);
+    }
+
+    .pill-row {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 8px;
+    }
+
+    .pill {
+      border: 1px solid var(--line);
+      background: #fff;
+      border-radius: 999px;
+      padding: 6px 10px;
+      font-size: 0.88rem;
+    }
+
+    .legend {
+      display: grid;
+      gap: 8px;
+      font-size: 0.9rem;
+    }
+
+    .legend-item {
+      display: flex;
+      align-items: center;
+      gap: 10px;
+    }
+
+    .swatch {
+      width: 14px;
+      height: 14px;
+      border-radius: 999px;
+      border: 1px solid rgba(0, 0, 0, 0.12);
+    }
+
+    .main {
+      display: grid;
+      grid-template-rows: auto 1fr;
+      gap: 16px;
+    }
+
+    .toolbar {
+      padding: 16px 18px;
+      display: flex;
+      flex-wrap: wrap;
+      align-items: center;
+      justify-content: space-between;
+      gap: 12px;
+    }
+
+    .toolbar strong {
+      font-size: 1rem;
+    }
+
+    .toolbar span {
+      color: var(--muted);
+      font-size: 0.92rem;
+    }
+
+    .viewer {
+      position: relative;
+      overflow: hidden;
+      min-height: 700px;
+    }
+
+    #cy {
+      position: absolute;
+      inset: 0;
+    }
+
+    .details {
+      position: absolute;
+      right: 16px;
+      bottom: 16px;
+      width: min(320px, calc(100% - 32px));
+      padding: 14px;
+      border-radius: 14px;
+      border: 1px solid var(--line);
+      background: rgba(255, 255, 255, 0.94);
+      box-shadow: var(--shadow);
+    }
+
+    .details h2 {
+      margin: 0 0 8px;
+      font-size: 1rem;
+    }
+
+    .details dl {
+      margin: 0;
+      display: grid;
+      grid-template-columns: 88px 1fr;
+      gap: 8px 10px;
+      font-size: 0.9rem;
+    }
+
+    .details dt {
+      color: var(--muted);
+    }
+
+    .details dd {
+      margin: 0;
+    }
+
+    @media (max-width: 980px) {
+      .shell {
+        grid-template-columns: 1fr;
+      }
+
+      .viewer {
+        min-height: 70vh;
+      }
+    }
+  </style>
+</head>
+<body>
+  <div class="shell">
+    <aside class="panel sidebar">
+      <div>
+        <h1>Wireup Graph POC</h1>
+        <p>Mocked data only. This is a proof of interaction style, not a real container export.</p>
+      </div>
+
+      <div class="field">
+        <label for="search">Search</label>
+        <input id="search" type="search" placeholder="WeatherService, infra, make_http_client">
+      </div>
+
+      <div class="group">
+        <div class="label">Layers</div>
+        <div class="toggle-list">
+          <label class="toggle"><input id="toggle-config" type="checkbox" checked> Configuration</label>
+          <label class="toggle"><input id="toggle-factories" type="checkbox" checked> Factories</label>
+          <label class="toggle"><input id="toggle-services" type="checkbox" checked> Services</label>
+          <label class="toggle"><input id="toggle-modules" type="checkbox" checked> Module containers</label>
+        </div>
+      </div>
+
+      <div class="group">
+        <div class="label">Focus</div>
+        <div class="pill-row">
+          <button class="pill" data-focus="all" type="button">Whole graph</button>
+          <button class="pill" data-focus="weather" type="button">Weather path</button>
+          <button class="pill" data-focus="config" type="button">Config only</button>
+          <button class="pill" data-focus="modules" type="button">Modules only</button>
+        </div>
+      </div>
+
+      <div class="group">
+        <div class="label">Legend</div>
+        <div class="legend">
+          <div class="legend-item"><span class="swatch" style="background: var(--service);"></span> Service</div>
+          <div class="legend-item"><span class="swatch" style="background: var(--factory);"></span> Factory result</div>
+          <div class="legend-item"><span class="swatch" style="background: var(--config);"></span> Config root</div>
+          <div class="legend-item"><span class="swatch" style="background: var(--module);"></span> Module group</div>
+        </div>
+      </div>
+    </aside>
+
+    <main class="main">
+      <div class="panel toolbar">
+        <div>
+          <strong>Interactive container sketch</strong>
+          <span>Click a node to isolate its neighborhood.</span>
+        </div>
+        <span id="summary">Showing all mocked nodes</span>
+      </div>
+
+      <section class="panel viewer">
+        <div id="cy"></div>
+        <section class="details" id="details">
+          <h2>No node selected</h2>
+          <dl>
+            <dt>Type</dt><dd>Click a node to inspect it</dd>
+            <dt>Module</dt><dd>-</dd>
+            <dt>Depends on</dt><dd>-</dd>
+            <dt>Used by</dt><dd>-</dd>
+          </dl>
+        </section>
+      </section>
+    </main>
+  </div>
+
+  <script src="https://unpkg.com/cytoscape@3.30.2/dist/cytoscape.min.js"></script>
+  <script>
+    const elements = [
+      { data: { id: "module:factories", label: "factories", kind: "module", module: "factories" } },
+      { data: { id: "module:services.kv", label: "services.kv", kind: "module", module: "services.kv" } },
+      { data: { id: "module:services.audit", label: "services.audit", kind: "module", module: "services.audit" } },
+      { data: { id: "module:services.weather", label: "services.weather", kind: "module", module: "services.weather" } },
+      { data: { id: "module:config", label: "Configuration", kind: "module", module: "config" } },
+
+      { data: { id: "config:env", label: "⚙ env", kind: "config", module: "config", parent: "module:config" } },
+      { data: { id: "config:infra", label: "⚙ infra", kind: "config", module: "config", parent: "module:config" } },
+      { data: { id: "config:services", label: "⚙ services", kind: "config", module: "config", parent: "module:config" } },
+      { data: { id: "config:messaging", label: "⚙ messaging", kind: "config", module: "config", parent: "module:config" } },
+
+      { data: { id: "factory:http", label: "🏭 HttpClient\nvia make_http_client", kind: "factory", module: "factories", parent: "module:factories" } },
+
+      { data: { id: "service:redis", label: "🐍 RedisConnection", kind: "service", module: "services.kv", parent: "module:services.kv" } },
+      { data: { id: "service:metrics", label: "🐍 MetricsClient", kind: "service", module: "services.kv", parent: "module:services.kv" } },
+      { data: { id: "service:kv", label: "🐍 KeyValueStore", kind: "service", module: "services.kv", parent: "module:services.kv" } },
+      { data: { id: "service:audit", label: "🐍 AuditService", kind: "service", module: "services.audit", parent: "module:services.audit" } },
+      { data: { id: "service:weather", label: "🐍 WeatherService", kind: "service", module: "services.weather", parent: "module:services.weather" } },
+
+      { data: { id: "e1", source: "config:infra", target: "service:redis", label: "dsn" } },
+      { data: { id: "e2", source: "config:infra", target: "service:metrics", label: "endpoint" } },
+      { data: { id: "e3", source: "service:redis", target: "service:kv", label: "redis" } },
+      { data: { id: "e4", source: "service:metrics", target: "service:kv", label: "metrics" } },
+      { data: { id: "e5", source: "config:services", target: "factory:http", label: "weather_url" } },
+      { data: { id: "e6", source: "service:kv", target: "service:audit", label: "kv_store" } },
+      { data: { id: "e7", source: "config:messaging", target: "service:audit", label: "topic" } },
+      { data: { id: "e8", source: "config:env", target: "service:audit", label: "topic" } },
+      { data: { id: "e9", source: "config:services", target: "service:weather", label: "api_key" } },
+      { data: { id: "e10", source: "config:services", target: "service:weather", label: "cache_key" } },
+      { data: { id: "e11", source: "config:env", target: "service:weather", label: "cache_key" } },
+      { data: { id: "e12", source: "factory:http", target: "service:weather", label: "client" } },
+      { data: { id: "e13", source: "service:kv", target: "service:weather", label: "kv_store" } },
+      { data: { id: "e14", source: "service:audit", target: "service:weather", label: "audit" } }
+    ];
+
+    const cy = cytoscape({
+      container: document.getElementById("cy"),
+      elements,
+      layout: {
+        name: "breadthfirst",
+        directed: true,
+        padding: 24,
+        spacingFactor: 1.15
+      },
+      wheelSensitivity: 0.15,
+      style: [
+        {
+          selector: "node",
+          style: {
+            "label": "data(label)",
+            "text-wrap": "wrap",
+            "text-max-width": 150,
+            "font-family": "IBM Plex Sans, Segoe UI, sans-serif",
+            "font-size": 12,
+            "text-valign": "center",
+            "text-halign": "center",
+            "border-width": 1.2,
+            "border-color": "#a39c8f",
+            "color": "#1f2328"
+          }
+        },
+        {
+          selector: 'node[kind = "service"]',
+          style: {
+            "shape": "round-rectangle",
+            "width": 158,
+            "height": 54,
+            "background-color": "#fff7ed"
+          }
+        },
+        {
+          selector: 'node[kind = "factory"]',
+          style: {
+            "shape": "round-rectangle",
+            "width": 168,
+            "height": 60,
+            "background-color": "#eef6ff"
+          }
+        },
+        {
+          selector: 'node[kind = "config"]',
+          style: {
+            "shape": "round-rectangle",
+            "width": 110,
+            "height": 42,
+            "background-color": "#f6f2ff"
+          }
+        },
+        {
+          selector: 'node[kind = "module"]',
+          style: {
+            "shape": "round-rectangle",
+            "padding": "22px",
+            "font-weight": 700,
+            "font-size": 15,
+            "text-valign": "top",
+            "text-halign": "center",
+            "background-color": "#fef3c7",
+            "border-style": "dashed",
+            "border-color": "#c39b28"
+          }
+        },
+        {
+          selector: "$node > node",
+          style: {
+            "text-margin-y": -12
+          }
+        },
+        {
+          selector: "edge",
+          style: {
+            "curve-style": "bezier",
+            "width": 2,
+            "line-color": "#8b95a7",
+            "target-arrow-color": "#8b95a7",
+            "target-arrow-shape": "triangle",
+            "arrow-scale": 0.9,
+            "label": "data(label)",
+            "font-size": 10,
+            "text-background-color": "#fff",
+            "text-background-opacity": 0.9,
+            "text-background-padding": 2,
+            "color": "#4b5563"
+          }
+        },
+        {
+          selector: ".dimmed",
+          style: {
+            "opacity": 0.12
+          }
+        },
+        {
+          selector: ".highlighted",
+          style: {
+            "border-color": "#b45309",
+            "border-width": 3,
+            "line-color": "#b45309",
+            "target-arrow-color": "#b45309",
+            "opacity": 1
+          }
+        },
+        {
+          selector: ".hidden",
+          style: {
+            "display": "none"
+          }
+        }
+      ]
+    });
+
+    const summary = document.getElementById("summary");
+    const details = document.getElementById("details");
+    const search = document.getElementById("search");
+    const toggleConfig = document.getElementById("toggle-config");
+    const toggleFactories = document.getElementById("toggle-factories");
+    const toggleServices = document.getElementById("toggle-services");
+    const toggleModules = document.getElementById("toggle-modules");
+
+    function visibleBaseNodes() {
+      return cy.nodes().filter((node) => {
+        const kind = node.data("kind");
+        if (kind === "config") return toggleConfig.checked;
+        if (kind === "factory") return toggleFactories.checked;
+        if (kind === "service") return toggleServices.checked;
+        if (kind === "module") return toggleModules.checked;
+        return true;
+      });
+    }
+
+    function applyVisibility() {
+      cy.elements().removeClass("hidden");
+
+      cy.nodes().forEach((node) => {
+        const kind = node.data("kind");
+        const shouldHide =
+          (kind === "config" && !toggleConfig.checked) ||
+          (kind === "factory" && !toggleFactories.checked) ||
+          (kind === "service" && !toggleServices.checked) ||
+          (kind === "module" && !toggleModules.checked);
+
+        if (shouldHide) {
+          node.addClass("hidden");
+        }
+      });
+
+      cy.edges().forEach((edge) => {
+        if (edge.source().hasClass("hidden") || edge.target().hasClass("hidden")) {
+          edge.addClass("hidden");
+        }
+      });
+
+      const q = search.value.trim().toLowerCase();
+      cy.elements().removeClass("dimmed");
+
+      if (q) {
+        const hits = cy.nodes().filter((node) => {
+          return !node.hasClass("hidden") && (
+            node.data("label").toLowerCase().includes(q) ||
+            node.data("module").toLowerCase().includes(q)
+          );
+        });
+
+        cy.elements().addClass("dimmed");
+        hits.removeClass("dimmed");
+        hits.connectedEdges().removeClass("dimmed");
+        hits.connectedEdges().connectedNodes().removeClass("dimmed");
+        summary.textContent = hits.length ? `Search matched ${hits.length} node(s)` : "No matches";
+      } else {
+        const visibleNodes = cy.nodes().filter((node) => !node.hasClass("hidden") && node.data("kind") !== "module");
+        summary.textContent = `Showing ${visibleNodes.length} visible node(s)`;
+      }
+    }
+
+    function showNeighborhood(node) {
+      cy.elements().removeClass("dimmed highlighted");
+      cy.elements().addClass("dimmed");
+
+      const neighborhood = node.closedNeighborhood().union(node.predecessors()).union(node.successors());
+      neighborhood.removeClass("dimmed");
+      neighborhood.addClass("highlighted");
+
+      const dependsOn = node.incomers("node").map((n) => n.data("label")).join(", ") || "-";
+      const usedBy = node.outgoers("node").map((n) => n.data("label")).join(", ") || "-";
+
+      details.innerHTML = `
+        <h2>${node.data("label").replace(/\n/g, " ")}</h2>
+        <dl>
+          <dt>Type</dt><dd>${node.data("kind")}</dd>
+          <dt>Module</dt><dd>${node.data("module")}</dd>
+          <dt>Depends on</dt><dd>${dependsOn}</dd>
+          <dt>Used by</dt><dd>${usedBy}</dd>
+        </dl>
+      `;
+    }
+
+    function resetFocus() {
+      cy.elements().removeClass("dimmed highlighted");
+      applyVisibility();
+      details.innerHTML = `
+        <h2>No node selected</h2>
+        <dl>
+          <dt>Type</dt><dd>Click a node to inspect it</dd>
+          <dt>Module</dt><dd>-</dd>
+          <dt>Depends on</dt><dd>-</dd>
+          <dt>Used by</dt><dd>-</dd>
+        </dl>
+      `;
+    }
+
+    document.querySelectorAll("[data-focus]").forEach((button) => {
+      button.addEventListener("click", () => {
+        resetFocus();
+
+        const mode = button.getAttribute("data-focus");
+        if (mode === "all") return;
+
+        cy.elements().addClass("dimmed");
+
+        let selected;
+        if (mode === "weather") {
+          selected = cy.getElementById("service:weather").closedNeighborhood()
+            .union(cy.getElementById("service:weather").predecessors());
+        } else if (mode === "config") {
+          selected = cy.nodes('[kind = "config"]').union(cy.edges().filter((edge) => edge.source().data("kind") === "config"));
+        } else if (mode === "modules") {
+          selected = cy.nodes('[kind = "module"]');
+        }
+
+        if (selected) {
+          selected.removeClass("dimmed");
+          selected.addClass("highlighted");
+        }
+      });
+    });
+
+    [toggleConfig, toggleFactories, toggleServices, toggleModules].forEach((checkbox) => {
+      checkbox.addEventListener("change", applyVisibility);
+    });
+
+    search.addEventListener("input", applyVisibility);
+
+    cy.on("tap", "node", (event) => {
+      if (event.target.data("kind") === "module") {
+        return;
+      }
+      showNeighborhood(event.target);
+    });
+
+    cy.on("tap", (event) => {
+      if (event.target === cy) {
+        resetFocus();
+      }
+    });
+
+    applyVisibility();
+  </script>
+</body>
+</html>

--- a/test/unit/test_inject_from_container.py
+++ b/test/unit/test_inject_from_container.py
@@ -9,6 +9,7 @@ from typing_extensions import Annotated
 from wireup import Inject, Injected, create_sync_container, inject_from_container, injectable, service
 from wireup._decorators import inject_from_container_unchecked
 from wireup.errors import WireupError
+from wireup.renderer._consumers import ConsumerMetadata, get_consumers
 
 from test.conftest import Container
 from test.unit import services
@@ -238,9 +239,52 @@ def test_inject_from_container_falsy_qualifier_injected() -> None:
         svc: Annotated[EmptyQualifierService, Inject(qualifier="")],
     ) -> None:
         assert isinstance(svc, EmptyQualifierService)
-        assert svc.name == "empty"
 
-    target()
+
+def test_inject_from_container_records_consumer_metadata() -> None:
+    container = create_sync_container(injectables=[services], config={"env_name": "test"})
+
+    @inject_from_container(container)
+    def target(foo: Injected[Foo]) -> Foo:
+        return foo
+
+    consumer = {consumer.id: consumer for consumer in get_consumers(container)}[
+        f"{target.__module__}.{target.__qualname__}"
+    ]
+    assert consumer.kind == "function"
+    assert consumer.label == f"ƒ {target.__qualname__}"
+    assert consumer.group == "test.unit.test_inject_from_container"
+    assert consumer.module == "test.unit.test_inject_from_container"
+    assert consumer.dependencies
+
+    resolved = target()
+    assert isinstance(resolved, FooImpl)
+
+
+def test_inject_from_container_allows_consumer_metadata_override() -> None:
+    container = create_sync_container(injectables=[services], config={"env_name": "test"})
+
+    @inject_from_container(
+        container,
+        consumer_metadata=ConsumerMetadata(
+            consumer_id="custom.consumer",
+            label="Custom Consumer",
+            kind="http_handler",
+            group="HTTP",
+            module="tests.http",
+        ),
+    )
+    def target(foo: Injected[Foo]) -> Foo:
+        return foo
+
+    consumer = {consumer.id: consumer for consumer in get_consumers(container)}["custom.consumer"]
+    assert consumer.kind == "http_handler"
+    assert consumer.label == "Custom Consumer"
+    assert consumer.group == "HTTP"
+    assert consumer.module == "tests.http"
+
+    resolved = target()
+    assert isinstance(resolved, FooImpl)
 
 
 async def test_container_sync_raises_async_def() -> None:

--- a/test/unit/test_renderer_core.py
+++ b/test/unit/test_renderer_core.py
@@ -1,0 +1,223 @@
+from __future__ import annotations
+
+import wireup
+import wireup.integration.fastapi as wireup_fastapi
+from fastapi import FastAPI
+from pet_store_demo_app import factories, fastapi_services, services
+from typing_extensions import Annotated
+from wireup import Inject, injectable
+from wireup._decorators import inject_from_container
+from wireup.integration.fastapi import setup
+from wireup.renderer._consumers import ConsumerMetadata
+from wireup.renderer._dependencies import ServiceDependencyReference
+from wireup.renderer.core import GraphOptions, to_graph_data
+
+
+@injectable(qualifier="primary")
+class QualifiedSearchBackend:
+    pass
+
+
+@injectable
+class QualifiedSearchService:
+    def __init__(self, backend: Annotated[QualifiedSearchBackend, Inject(qualifier="primary")]) -> None:
+        self.backend = backend
+
+
+@injectable
+class ConfigDrivenService:
+    def __init__(
+        self,
+        settings: Annotated[str, Inject(expr="${infra.database.url}-${infra.database.schema}-${env.name}")],
+    ) -> None:
+        self.settings = settings
+
+
+@injectable
+class AuditBackend:
+    pass
+
+
+@injectable
+class HandlerService:
+    pass
+
+
+def _create_graph_data():
+    app = FastAPI()
+
+    @app.get("/db-session")
+    async def db_session(service: wireup.Injected[services.SQLAlchemySession]) -> dict[str, str]:
+        return service.describe()
+
+    @app.get("/pets")
+    async def list_pets(service: wireup.Injected[services.PetCatalogService]) -> dict[str, object]:
+        return service.list_pets()
+
+    @app.get("/whoami")
+    async def whoami(service: wireup.Injected[fastapi_services.AuthService]) -> dict[str, str]:
+        return service.describe()
+
+    container = wireup.create_async_container(
+        injectables=[factories, services, fastapi_services, wireup_fastapi],
+        config={
+            "auth": {"demo_actor": "shelter-manager"},
+            "env": {"name": "demo"},
+            "infra": {
+                "redis": {"url": "redis://localhost:6379/0"},
+                "metrics": {"endpoint": "http://metrics.internal"},
+                "database": {
+                    "url": "postgresql+psycopg://petstore:petstore@localhost:5432/petstore",
+                    "schema": "adoption",
+                },
+            },
+            "services": {"search": {"base_url": "https://search.petstore.example"}},
+            "pets": {"store_name": "Happy Tails Shelter", "default_species": "cat"},
+            "messaging": {"events": {"topic_prefix": "petstore-events"}},
+        },
+    )
+
+    setup(container, app)
+    return to_graph_data(container, options=GraphOptions(base_module="pet_store_demo_app"))
+
+
+def test_to_graph_data_returns_expected_groups_nodes_and_edges() -> None:
+    graph = _create_graph_data()
+
+    group_ids = {group.id for group in graph.groups}
+    assert group_ids >= {
+        "group_Configuration",
+        "group_FastAPI",
+        "group_factories",
+        "group_services_adoption",
+        "group_services_audit",
+        "group_services_infra",
+        "group_services_owners",
+        "group_services_pets",
+        "group_services_session",
+    }
+
+    nodes_by_id = {node.id: node for node in graph.nodes}
+    assert nodes_by_id["consumer_GET_pets"].label == "🌐 GET /pets"
+    assert nodes_by_id["consumer_GET_db_session"].label == "🌐 GET /db-session"
+    assert nodes_by_id["consumer_GET_whoami"].label == "🌐 GET /whoami"
+    assert nodes_by_id["pet_store_demo_app_factories_SearchClient"].factory_name == "make_search_client"
+    assert (
+        nodes_by_id["pet_store_demo_app_services_pets_PetCatalogService"].module
+        == "pet_store_demo_app.services.pets"
+    )
+    assert nodes_by_id["pet_store_demo_app_fastapi_services_AuthService"].lifetime == "scoped"
+    assert nodes_by_id["pet_store_demo_app_services_adoption_AdoptionService"].group == "services.adoption"
+    assert nodes_by_id["pet_store_demo_app_services_owners_OwnerService"].group == "services.owners"
+    assert nodes_by_id["pet_store_demo_app_services_session_SQLAlchemySession"].lifetime == "scoped"
+
+    edges = {(edge.source, edge.target, edge.label) for edge in graph.edges}
+    assert ("config_services", "pet_store_demo_app_factories_SearchClient", "search_url") in edges
+    assert (
+        "pet_store_demo_app_factories_SearchClient",
+        "pet_store_demo_app_services_pets_PetCatalogService",
+        "search",
+    ) in edges
+    assert (
+        "pet_store_demo_app_services_pets_PetCatalogService",
+        "pet_store_demo_app_services_adoption_AdoptionService",
+        "catalog",
+    ) in edges
+    assert (
+        "pet_store_demo_app_services_infra_ShelterStore",
+        "pet_store_demo_app_services_audit_AuditService",
+        "shelter_store",
+    ) in edges
+    assert (
+        "pet_store_demo_app_services_pets_PetCatalogService",
+        "consumer_GET_pets",
+        "service",
+    ) in edges
+    assert (
+        "pet_store_demo_app_services_session_SQLAlchemySession",
+        "consumer_GET_db_session",
+        "service",
+    ) in edges
+    assert (
+        "pet_store_demo_app_fastapi_services_AuthService",
+        "consumer_GET_whoami",
+        "service",
+    ) in edges
+
+
+def test_to_graph_data_includes_qualified_service_nodes() -> None:
+    container = wireup.create_sync_container(injectables=[QualifiedSearchBackend, QualifiedSearchService])
+
+    graph = to_graph_data(container)
+
+    nodes_by_id = {node.id: node for node in graph.nodes}
+    assert "test_unit_test_renderer_core_QualifiedSearchBackend_primary" in nodes_by_id
+    assert (
+        nodes_by_id["test_unit_test_renderer_core_QualifiedSearchBackend_primary"].label
+        == "🐍 QualifiedSearchBackend [primary]"
+    )
+    assert (
+        "test_unit_test_renderer_core_QualifiedSearchBackend_primary",
+        "test_unit_test_renderer_core_QualifiedSearchService",
+        "backend",
+    ) in {(edge.source, edge.target, edge.label) for edge in graph.edges}
+
+
+def test_to_graph_data_collapses_config_dependencies_to_root_keys() -> None:
+    container = wireup.create_sync_container(
+        injectables=[ConfigDrivenService],
+        config={
+            "env": {"name": "demo"},
+            "infra": {"database": {"url": "postgresql://demo", "schema": "public"}},
+        },
+    )
+
+    graph = to_graph_data(container)
+
+    nodes_by_id = {node.id: node for node in graph.nodes}
+    assert "config_infra" in nodes_by_id
+    assert "config_env" in nodes_by_id
+    assert "config_infra_database" not in nodes_by_id
+
+    service_node_id = "test_unit_test_renderer_core_ConfigDrivenService"
+    edge_refs = {(edge.source, edge.target, edge.label) for edge in graph.edges}
+    assert ("config_infra", service_node_id, "settings") in edge_refs
+    assert ("config_env", service_node_id, "settings") in edge_refs
+    assert len([edge for edge in graph.edges if edge.target == service_node_id]) == 2
+
+
+def test_to_graph_data_uses_custom_consumer_metadata_and_extra_dependencies() -> None:
+    container = wireup.create_sync_container(injectables=[AuditBackend, HandlerService])
+
+    @inject_from_container(
+        container,
+        consumer_metadata=ConsumerMetadata(
+            consumer_id="custom.route",
+            label="🌐 GET /custom",
+            kind="fastapi_route",
+            group="FastAPI",
+            module="tests.handlers",
+            extra_dependencies=(
+                ServiceDependencyReference(
+                    param_name="audit_backend",
+                    service_id=f"{AuditBackend.__module__}.{AuditBackend.__qualname__}",
+                    qualifier=None,
+                ),
+            ),
+        ),
+    )
+    def handler(service: wireup.Injected[HandlerService]) -> None:
+        assert service is not None
+
+    handler()
+
+    graph = to_graph_data(container)
+
+    nodes_by_id = {node.id: node for node in graph.nodes}
+    assert nodes_by_id["consumer_custom_route"].label == "🌐 GET /custom"
+    assert nodes_by_id["consumer_custom_route"].group == "FastAPI"
+    assert nodes_by_id["consumer_custom_route"].module == "tests.handlers"
+
+    edge_refs = {(edge.source, edge.target, edge.label) for edge in graph.edges}
+    assert ("test_unit_test_renderer_core_HandlerService", "consumer_custom_route", "service") in edge_refs
+    assert ("test_unit_test_renderer_core_AuditBackend", "consumer_custom_route", "audit_backend") in edge_refs

--- a/wireup/_decorators.py
+++ b/wireup/_decorators.py
@@ -15,6 +15,7 @@ from wireup.ioc.util import (
     get_inject_annotated_parameters,
     get_valid_injection_annotated_parameters,
 )
+from wireup.renderer._consumers import ConsumerMetadata, record_injected_consumer
 
 if TYPE_CHECKING:
     from wireup.ioc.container.async_container import AsyncContainer, ScopedAsyncContainer
@@ -60,6 +61,7 @@ def inject_from_container(
     container: SyncContainer | AsyncContainer,
     scoped_container_supplier: Callable[[], ScopedSyncContainer | ScopedAsyncContainer] | None = None,
     _context_creator: dict[Any, str] | None = None,
+    consumer_metadata: ConsumerMetadata | None = None,
     *,
     hide_annotated_names: bool = False,
 ) -> Callable[[Callable[P, R]], Callable[..., R]]:
@@ -88,6 +90,7 @@ def inject_from_container(
             container=container,
             scoped_container_supplier=scoped_container_supplier,
             context_creator=_context_creator,
+            consumer_metadata=consumer_metadata,
             hide_annotated_names=hide_annotated_names,
         )
 
@@ -100,6 +103,7 @@ def inject_from_container_util(  # noqa: PLR0913
     container: SyncContainer | AsyncContainer | None,
     scoped_container_supplier: Callable[[], ScopedSyncContainer | ScopedAsyncContainer] | None = None,
     context_creator: dict[Any, str] | None = None,
+    consumer_metadata: ConsumerMetadata | None = None,
     *,
     hide_annotated_names: bool,
 ) -> Callable[..., R]:
@@ -109,6 +113,14 @@ def inject_from_container_util(  # noqa: PLR0913
 
     if not names_to_inject:
         return target
+
+    if container is not None:
+        record_injected_consumer(
+            container,
+            target=target,
+            names_to_inject=names_to_inject,
+            metadata=consumer_metadata,
+        )
 
     res = compile_injection_wrapper(
         target=target,

--- a/wireup/integration/django/__init__.py
+++ b/wireup/integration/django/__init__.py
@@ -1,4 +1,9 @@
-from wireup.integration.django.apps import WireupSettings, get_app_container, get_request_container, wireup_middleware
+from wireup.integration.django.apps import (
+    WireupSettings,
+    get_app_container,
+    get_request_container,
+    wireup_middleware,
+)
 from wireup.integration.django.decorators import inject, inject_app
 
 __all__ = [

--- a/wireup/integration/django/apps.py
+++ b/wireup/integration/django/apps.py
@@ -1,11 +1,12 @@
+from __future__ import annotations
+
 import functools
 import importlib
 import inspect
 import warnings
 from contextvars import ContextVar
 from dataclasses import dataclass
-from types import ModuleType
-from typing import TYPE_CHECKING, Any, Awaitable, Callable, List, Optional, Union
+from typing import TYPE_CHECKING, Any, Awaitable, Callable
 
 import django
 import django.urls
@@ -20,13 +21,15 @@ from wireup import injectable
 from wireup._decorators import inject_from_container
 from wireup.errors import WireupError
 from wireup.ioc.container.async_container import AsyncContainer, ScopedAsyncContainer, async_container_force_sync_scope
-from wireup.ioc.container.base_container import BaseContainer
-from wireup.ioc.container.sync_container import ScopedSyncContainer
 from wireup.ioc.types import ConfigInjectionRequest
 from wireup.ioc.util import get_valid_injection_annotated_parameters
 
 if TYPE_CHECKING:
+    from types import ModuleType
+
     from wireup.integration.django import WireupSettings
+    from wireup.ioc.container.base_container import BaseContainer
+    from wireup.ioc.container.sync_container import ScopedSyncContainer
 
 
 _request_container: ContextVar[BaseContainer] = ContextVar("_wireup_request_container")
@@ -35,7 +38,7 @@ _request_container: ContextVar[BaseContainer] = ContextVar("_wireup_request_cont
 @sync_and_async_middleware
 def wireup_middleware(
     get_response: Callable[[HttpRequest], HttpResponse],
-) -> Callable[[HttpRequest], Union[HttpResponse, Awaitable[HttpResponse]]]:
+) -> Callable[[HttpRequest], HttpResponse | Awaitable[HttpResponse]]:
     container = get_app_container()
 
     if inspect.iscoroutinefunction(get_response):
@@ -70,7 +73,7 @@ def _django_request_factory() -> HttpRequest:
     raise WireupError(msg)
 
 
-def get_request_container() -> Union[ScopedSyncContainer, ScopedAsyncContainer]:
+def get_request_container() -> ScopedSyncContainer | ScopedAsyncContainer:
     """When inside a request, returns the scoped container instance handling the current request."""
     try:
         return _request_container.get()  # type:ignore[reportReturnType]
@@ -176,10 +179,10 @@ class WireupConfig(AppConfig):
 class WireupSettings:
     """Class containing Wireup settings specific to Django."""
 
-    service_modules: Optional[List[Union[str, ModuleType]]] = None
+    service_modules: list[str | ModuleType] | None = None
     """List of modules containing wireup injectable registrations."""
 
-    injectables: Optional[List[Union[str, ModuleType]]] = None
+    injectables: list[str | ModuleType] | None = None
     """List of modules containing wireup injectable registrations."""
 
     auto_inject_views: bool = True

--- a/wireup/integration/fastapi.py
+++ b/wireup/integration/fastapi.py
@@ -1,20 +1,12 @@
+from __future__ import annotations
+
 import contextlib
-from typing import (
-    Any,
-    AsyncIterator,
-    Callable,
-    Iterable,
-    List,
-    Optional,
-    Tuple,
-    Type,
-    Union,
-)
+from typing import TYPE_CHECKING, Any, AsyncIterator, Callable, Iterable
 
 import fastapi
 from fastapi import FastAPI, Request, WebSocket
+from fastapi.responses import HTMLResponse
 from fastapi.routing import APIRoute, APIWebSocketRoute
-from starlette.routing import BaseRoute
 from typing_extensions import Protocol
 
 from wireup import inject_from_container
@@ -30,14 +22,21 @@ from wireup.integration.starlette import (
     request_factory,
     websocket_factory,
 )
-from wireup.ioc.container.async_container import AsyncContainer
-from wireup.ioc.types import AnyCallable
 from wireup.ioc.util import (
     get_inject_annotated_parameters,
     hide_annotated_names,
     injection_requires_scope,
     is_wireup_injected,
 )
+from wireup.renderer._consumers import ConsumerMetadata
+from wireup.renderer._dependencies import DependencyReference, ServiceDependencyReference
+from wireup.renderer.full_page import GraphEndpointOptions, render_graph_page
+
+if TYPE_CHECKING:
+    from starlette.routing import BaseRoute
+
+    from wireup.ioc.container.async_container import AsyncContainer
+    from wireup.ioc.types import AnyCallable
 
 __all__ = [
     "WireupRoute",
@@ -61,11 +60,12 @@ class WireupRoute(APIRoute):
         super().__init__(path=path, endpoint=endpoint, **kwargs)
 
 
-def _inject_route_with_connection_context(
+def _inject_route_with_connection_context(  # noqa: PLR0913
     *,
     container: AsyncContainer,
     target: AnyCallable,
-    http_connection_param_name: Optional[str],
+    consumer_metadata: ConsumerMetadata,
+    http_connection_param_name: str | None,
     remove_http_connection_from_arguments: bool,
     is_websocket_route: bool,
 ) -> AnyCallable:
@@ -78,10 +78,11 @@ def _inject_route_with_connection_context(
         }
         if http_connection_param_name
         else None,
+        consumer_metadata=consumer_metadata,
     )(target)
 
 
-def _ensure_http_connection_param(route: Union[APIRoute, APIWebSocketRoute]) -> Tuple[str, bool]:
+def _ensure_http_connection_param(route: APIRoute | APIWebSocketRoute) -> tuple[str, bool]:
     """Ensure FastAPI will pass the active connection and return param name + remove flag."""
     has_connection_param_in_signature = route.dependant.http_connection_param_name is not None
     if not route.dependant.http_connection_param_name:
@@ -90,9 +91,35 @@ def _ensure_http_connection_param(route: Union[APIRoute, APIWebSocketRoute]) -> 
     return route.dependant.http_connection_param_name, not has_connection_param_in_signature
 
 
+def _get_consumer_metadata(route: APIRoute | APIWebSocketRoute) -> ConsumerMetadata:
+    methods = () if isinstance(route, APIWebSocketRoute) else tuple(sorted(route.methods or []))
+    method_label = "WS" if isinstance(route, APIWebSocketRoute) else "|".join(methods) if methods else "ROUTE"
+    consumer_id = f"{method_label} {route.path}"
+    extra_dependencies: tuple[DependencyReference, ...] = ()
+
+    bound_instance = getattr(route.dependant.call, "__self__", None)
+    if bound_instance is not None:
+        extra_dependencies = (
+            ServiceDependencyReference(
+                param_name="handler",
+                service_id=f"{bound_instance.__class__.__module__}.{bound_instance.__class__.__qualname__}",
+                qualifier=None,
+            ),
+        )
+
+    return ConsumerMetadata(
+        consumer_id=consumer_id,
+        kind="fastapi_websocket" if isinstance(route, APIWebSocketRoute) else "fastapi_route",
+        label=f"🌐 {consumer_id}",
+        group="FastAPI",
+        module=route.dependant.call.__module__,
+        extra_dependencies=extra_dependencies,
+    )
+
+
 def _inject_routes(
     container: AsyncContainer,
-    routes: List[BaseRoute],
+    routes: list[BaseRoute],
     *,
     is_using_asgi_middleware: bool,
 ) -> None:
@@ -109,10 +136,16 @@ def _inject_routes(
         if not names_to_inject:
             continue
 
+        consumer_metadata = _get_consumer_metadata(route)
+
         # When using the asgi middleware, the request context variable is set there.
         # and we can get the scoped container from the request.
         if isinstance(route, APIRoute) and is_using_asgi_middleware:
-            route.dependant.call = inject_from_container(container, get_request_container)(route.dependant.call)
+            route.dependant.call = inject_from_container(
+                container,
+                get_request_container,
+                consumer_metadata=consumer_metadata,
+            )(route.dependant.call)
             continue
 
         # We now are either in a websocket endpoint or HTTP without middleware_mode.
@@ -126,16 +159,30 @@ def _inject_routes(
         route.dependant.call = _inject_route_with_connection_context(
             container=container,
             target=route.dependant.call,
+            consumer_metadata=consumer_metadata,
             http_connection_param_name=http_connection_param_name,
             remove_http_connection_from_arguments=remove_http_connection_from_arguments,
             is_websocket_route=isinstance(route, APIWebSocketRoute),
         )
 
 
+def _setup_graph_routes(app: FastAPI, *, options: GraphEndpointOptions) -> None:
+    async def _wireup_graph_page(request: Request) -> HTMLResponse:
+        return HTMLResponse(
+            render_graph_page(
+                get_app_container(request.app),
+                title=f"{app.title} - Wireup Graph",
+                options=options,
+            )
+        )
+
+    app.add_api_route("/_wireup", _wireup_graph_page, methods=["GET"], response_class=HTMLResponse)
+
+
 async def _instantiate_class_based_route(
     app: FastAPI,
     container: AsyncContainer,
-    cls: Type[_ClassBasedHandlersProtocol],
+    cls: type[_ClassBasedHandlersProtocol],
 ) -> None:
     instance = await container.get(cls)
 
@@ -164,7 +211,7 @@ async def _instantiate_class_based_route(
 
 def _update_lifespan(
     app: FastAPI,
-    class_based_routes: Optional[Iterable[Type[_ClassBasedHandlersProtocol]]] = None,
+    class_based_routes: Iterable[type[_ClassBasedHandlersProtocol]] | None = None,
     *,
     is_using_asgi_middleware: bool,
 ) -> None:
@@ -194,12 +241,14 @@ def _update_lifespan(
     app.router.lifespan_context = lifespan
 
 
-def setup(
+def setup(  # noqa: PLR0913
     container: AsyncContainer,
     app: FastAPI,
     *,
-    class_based_handlers: Optional[Iterable[Type[_ClassBasedHandlersProtocol]]] = None,
+    class_based_handlers: Iterable[type[_ClassBasedHandlersProtocol]] | None = None,
     middleware_mode: bool = False,
+    add_graph_endpoint: bool = False,
+    graph_endpoint_options: GraphEndpointOptions | None = None,
 ) -> None:
     """Integrate Wireup with FastAPI.
 
@@ -216,11 +265,16 @@ def setup(
     Warning: Do not include these with fastapi directly.
     :param middleware_mode: If True, the container is exposed in fastapi middleware.
     Note, for this to work correctly, there should be no more middleware added after the call to this function.
+    :param add_graph_endpoint: If True, mount the `/_wireup` endpoint exposing
+        the Wireup graph viewer and raw graph JSON.
+    :param graph_endpoint_options: Optional graph endpoint configuration.
 
     For more details, visit: https://maldoinc.github.io/wireup/latest/integrations/fastapi/
     """
     app.state.wireup_container = container
     _expose_wireup_task(container)
+    if add_graph_endpoint:
+        _setup_graph_routes(app, options=graph_endpoint_options or GraphEndpointOptions())
     if middleware_mode:
         app.add_middleware(WireupAsgiMiddleware, include_websocket=False)
     _update_lifespan(

--- a/wireup/integration/flask.py
+++ b/wireup/integration/flask.py
@@ -1,18 +1,72 @@
-from typing import Optional
+from __future__ import annotations
 
-from flask import Flask, g
+from typing import TYPE_CHECKING
+
+from flask import Flask, Response, g
 
 from wireup._decorators import inject_from_container
-from wireup.ioc.container.sync_container import ScopedSyncContainer, SyncContainer
+from wireup.renderer._consumers import ConsumerMetadata
+from wireup.renderer.full_page import GraphEndpointOptions, render_graph_page
+
+if TYPE_CHECKING:
+    from wireup.ioc.container.sync_container import ScopedSyncContainer, SyncContainer
+
+__all__ = [
+    "GraphEndpointOptions",
+    "get_app_container",
+    "get_request_container",
+    "setup",
+]
 
 
 def _inject_views(container: SyncContainer, app: Flask) -> None:
-    inject_scoped = inject_from_container(container, get_request_container)
+    app.view_functions = {
+        endpoint: inject_from_container(
+            container,
+            get_request_container,
+            consumer_metadata=_flask_consumer_metadata(app, endpoint, view),
+        )(view)
+        for endpoint, view in app.view_functions.items()
+    }
 
-    app.view_functions = {name: inject_scoped(view) for name, view in app.view_functions.items()}
+
+def _flask_consumer_metadata(app: Flask, endpoint: str, view: object) -> ConsumerMetadata:
+    rules = sorted((rule for rule in app.url_map.iter_rules() if rule.endpoint == endpoint), key=lambda item: item.rule)
+    paths = tuple(rule.rule for rule in rules)
+    methods = tuple(dict.fromkeys(method for rule in rules for method in sorted(rule.methods - {"HEAD", "OPTIONS"})))
+    method_label = "|".join(methods) if methods else "ROUTE"
+    path_label = ", ".join(paths) if paths else endpoint
+    consumer_id = f"{method_label} {path_label}"
+
+    return ConsumerMetadata(
+        consumer_id=consumer_id,
+        kind="flask_route",
+        label=f"🌐 {consumer_id}",
+        group="Flask",
+        module=getattr(view, "__module__", "unknown"),
+    )
 
 
-def setup(container: SyncContainer, app: Flask) -> None:
+def _setup_graph_route(app: Flask, *, options: GraphEndpointOptions) -> None:
+    @app.get("/_wireup")
+    def _wireup_graph_page() -> Response:
+        return Response(
+            render_graph_page(
+                get_app_container(app),
+                title=f"{app.name} - Wireup Graph",
+                options=options,
+            ),
+            mimetype="text/html",
+        )
+
+
+def setup(
+    container: SyncContainer,
+    app: Flask,
+    *,
+    add_graph_endpoint: bool = False,
+    graph_endpoint_options: GraphEndpointOptions | None = None,
+) -> None:
     """Integrate Wireup with Flask.
 
     Setup performs the following:
@@ -25,13 +79,15 @@ def setup(container: SyncContainer, app: Flask) -> None:
         g.wireup_container_ctx = ctx
         g.wireup_container = ctx.__enter__()
 
-    def _teardown_request(exc: Optional[BaseException] = None) -> None:
+    def _teardown_request(exc: BaseException | None = None) -> None:
         if ctx := getattr(g, "wireup_container_ctx", None):
             ctx.__exit__(type(exc) if exc else None, exc, exc.__traceback__ if exc else None)
 
     app.before_request(_before_request)
     app.teardown_request(_teardown_request)
 
+    if add_graph_endpoint:
+        _setup_graph_route(app, options=graph_endpoint_options or GraphEndpointOptions())
     _inject_views(container, app)
     app.wireup_container = container  # type: ignore[reportAttributeAccessIssue]
 

--- a/wireup/ioc/container/base_container.py
+++ b/wireup/ioc/container/base_container.py
@@ -31,6 +31,7 @@ T = TypeVar("T")
 
 class BaseContainer:
     __slots__ = (
+        "__weakref__",
         "_compiler",
         "_concurrent_scoped_access",
         "_current_scope_exit_stack",

--- a/wireup/renderer/_consumers.py
+++ b/wireup/renderer/_consumers.py
@@ -1,0 +1,94 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any
+from weakref import WeakKeyDictionary
+
+from wireup.renderer._dependencies import DependencyReference, resolve_dependencies
+
+if TYPE_CHECKING:
+    from wireup.ioc.container.base_container import BaseContainer
+    from wireup.ioc.types import AnnotatedParameter
+
+
+@dataclass(frozen=True)
+class ConsumerRecord:
+    kind: str
+    id: str
+    label: str
+    group: str
+    module: str
+    dependencies: tuple[DependencyReference, ...]
+
+
+@dataclass(frozen=True)
+class ConsumerMetadata:
+    consumer_id: str | None = None
+    label: str | None = None
+    kind: str = "function"
+    group: str | None = None
+    module: str | None = None
+    extra_dependencies: tuple[DependencyReference, ...] = ()
+
+
+_CONSUMERS_BY_CONTAINER: WeakKeyDictionary[BaseContainer, dict[str, ConsumerRecord]] = WeakKeyDictionary()
+
+
+def record_consumer(  # noqa: PLR0913
+    container: BaseContainer,
+    *,
+    kind: str,
+    consumer_id: str,
+    label: str,
+    group: str,
+    module: str,
+    names_to_inject: dict[str, AnnotatedParameter],
+    extra_dependencies: tuple[DependencyReference, ...] = (),
+) -> None:
+    _CONSUMERS_BY_CONTAINER.setdefault(container, {})[consumer_id] = ConsumerRecord(
+        kind=kind,
+        id=consumer_id,
+        label=label,
+        group=group,
+        module=module,
+        dependencies=resolve_dependencies(container, names_to_inject) + extra_dependencies,
+    )
+
+
+def get_consumers(container: BaseContainer) -> tuple[ConsumerRecord, ...]:
+    return tuple(_CONSUMERS_BY_CONTAINER.get(container, {}).values())
+
+
+def infer_consumer_metadata(target: Any) -> ConsumerMetadata:
+    module = getattr(target, "__module__", "unknown")
+    qualname = getattr(target, "__qualname__", getattr(target, "__name__", repr(target)))
+    consumer_id = f"{module}.{qualname}"
+
+    return ConsumerMetadata(
+        consumer_id=consumer_id,
+        label=f"ƒ {qualname}",
+        group=module,
+        module=module,
+    )
+
+
+def record_injected_consumer(
+    container: BaseContainer,
+    *,
+    target: Any,
+    names_to_inject: dict[str, AnnotatedParameter],
+    metadata: ConsumerMetadata | None = None,
+) -> None:
+    inferred = infer_consumer_metadata(target)
+    provided = metadata or ConsumerMetadata()
+
+    record_consumer(
+        container,
+        kind=provided.kind,
+        consumer_id=provided.consumer_id or inferred.consumer_id or repr(target),
+        label=provided.label or inferred.label or repr(target),
+        group=provided.group or inferred.group or "Functions",
+        module=provided.module or inferred.module or "unknown",
+        names_to_inject=names_to_inject,
+        extra_dependencies=provided.extra_dependencies,
+    )

--- a/wireup/renderer/_dependencies.py
+++ b/wireup/renderer/_dependencies.py
@@ -1,0 +1,77 @@
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any
+
+from typing_extensions import TypeAlias
+
+from wireup.ioc.types import ConfigInjectionRequest, TemplatedString
+
+if TYPE_CHECKING:
+    from wireup.ioc.container.base_container import BaseContainer
+    from wireup.ioc.types import AnnotatedParameter
+
+_CONFIG_REF_PATTERN = re.compile(r"\${(.*?)}", flags=re.DOTALL)
+
+
+@dataclass(frozen=True)
+class ConfigDependencyReference:
+    param_name: str
+    config_keys: tuple[str, ...]
+
+
+@dataclass(frozen=True)
+class ServiceDependencyReference:
+    param_name: str
+    service_id: str
+    qualifier: Any = None
+
+
+DependencyReference: TypeAlias = ConfigDependencyReference | ServiceDependencyReference
+
+
+def resolve_dependencies(
+    container: BaseContainer,
+    names_to_inject: dict[str, AnnotatedParameter],
+) -> tuple[DependencyReference, ...]:
+    dependencies: list[DependencyReference] = []
+
+    for param_name, parameter in names_to_inject.items():
+        config_keys = extract_config_sources(parameter.annotation)
+        if config_keys:
+            dependencies.append(
+                ConfigDependencyReference(
+                    param_name=param_name,
+                    config_keys=config_keys,
+                )
+            )
+            continue
+
+        impl = container._registry.get_implementation(parameter.klass, parameter.qualifier_value)
+        dependencies.append(
+            ServiceDependencyReference(
+                param_name=param_name,
+                service_id=f"{impl.__module__}.{impl.__qualname__}",
+                qualifier=parameter.qualifier_value,
+            )
+        )
+
+    return tuple(dependencies)
+
+
+def extract_config_sources(annotation: object) -> tuple[str, ...]:
+    if not isinstance(annotation, ConfigInjectionRequest):
+        return ()
+
+    config_key = annotation.config_key
+    if isinstance(config_key, TemplatedString):
+        keys = set(_CONFIG_REF_PATTERN.findall(config_key.value))
+    else:
+        keys = {config_key}
+
+    return tuple({_collapse_config_key(key) for key in keys})
+
+
+def _collapse_config_key(key: str) -> str:
+    return key if "." not in key else key.split(".", maxsplit=1)[0]

--- a/wireup/renderer/core.py
+++ b/wireup/renderer/core.py
@@ -1,0 +1,260 @@
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any
+
+from wireup.renderer._consumers import get_consumers
+from wireup.renderer._dependencies import (
+    ConfigDependencyReference,
+    DependencyReference,
+    resolve_dependencies,
+)
+
+if TYPE_CHECKING:
+    from wireup.ioc.container.base_container import BaseContainer
+    from wireup.ioc.registry import InjectableFactory
+    from wireup.ioc.types import ContainerObjectIdentifier, Qualifier
+    from wireup.renderer._consumers import ConsumerRecord
+
+
+@dataclass(frozen=True)
+class GraphOptions:
+    base_module: str | None = None
+
+
+@dataclass(frozen=True)
+class GraphGroup:
+    id: str
+    label: str
+    kind: str
+    module: str
+
+
+@dataclass(frozen=True)
+class GraphNode:
+    id: str
+    label: str
+    kind: str
+    lifetime: str | None
+    module: str
+    parent: str
+    original_parent: str
+    group: str
+    factory_name: str | None
+
+
+@dataclass(frozen=True)
+class GraphEdge:
+    id: str
+    source: str
+    target: str
+    label: str
+    kind: str
+
+
+@dataclass(frozen=True)
+class GraphData:
+    groups: tuple[GraphGroup, ...]
+    nodes: tuple[GraphNode, ...]
+    edges: tuple[GraphEdge, ...]
+
+
+def to_graph_data(container: BaseContainer, *, options: GraphOptions | None = None) -> GraphData:
+    opts = options or GraphOptions()
+    service_nodes = _service_nodes(container, base_module=opts.base_module)
+    consumer_nodes = _consumer_nodes(container)
+    config_nodes: dict[str, GraphNode] = {}
+    edge_refs: set[tuple[str, str, str]] = set()
+
+    for node, dependencies in [*service_nodes.values(), *consumer_nodes.values()]:
+        _collect_edges(
+            dependencies,
+            target_node_id=node.id,
+            service_nodes=service_nodes,
+            config_nodes=config_nodes,
+            edge_refs=edge_refs,
+        )
+
+    nodes = tuple(
+        sorted(
+            [
+                *config_nodes.values(),
+                *(node for node, _ in service_nodes.values()),
+                *(node for node, _ in consumer_nodes.values()),
+            ],
+            key=lambda item: item.id,
+        )
+    )
+    groups = tuple(sorted(_groups_for_nodes(nodes), key=lambda item: item.id))
+    edges = tuple(
+        GraphEdge(
+            id=f"edge_{index}",
+            source=source,
+            target=target,
+            label=label,
+            kind="dependency",
+        )
+        for index, (source, target, label) in enumerate(sorted(edge_refs))
+    )
+    return GraphData(groups=groups, nodes=nodes, edges=edges)
+
+
+def _service_nodes(
+    container: BaseContainer,
+    *,
+    base_module: str | None,
+) -> dict[str, tuple[GraphNode, tuple[DependencyReference, ...]]]:
+    registry = container._registry
+    nodes: dict[str, tuple[GraphNode, tuple[DependencyReference, ...]]] = {}
+
+    for obj_id in registry.factories:
+        impl, qualifier = _split_obj_id(obj_id)
+        factory = registry.factories[obj_id]
+        node = _service_node(impl, qualifier, factory, registry.lifetime[obj_id], base_module)
+        dependencies = resolve_dependencies(container, registry.dependencies[factory.factory])
+        nodes[node.id] = (node, dependencies)
+
+    return nodes
+
+
+def _consumer_nodes(
+    container: BaseContainer,
+) -> dict[str, tuple[GraphNode, tuple[DependencyReference, ...]]]:
+    nodes: dict[str, tuple[GraphNode, tuple[DependencyReference, ...]]] = {}
+    for consumer in get_consumers(container):
+        node = _consumer_node(consumer)
+        nodes[node.id] = (node, consumer.dependencies)
+
+    return nodes
+
+
+def _collect_edges(
+    dependencies: tuple[DependencyReference, ...],
+    *,
+    target_node_id: str,
+    service_nodes: dict[str, tuple[GraphNode, tuple[DependencyReference, ...]]],
+    config_nodes: dict[str, GraphNode],
+    edge_refs: set[tuple[str, str, str]],
+) -> None:
+    for dependency in dependencies:
+        if isinstance(dependency, ConfigDependencyReference):
+            for config_key in dependency.config_keys:
+                config_node = _config_node(config_key)
+                config_nodes[config_node.id] = config_node
+                edge_refs.add((config_node.id, target_node_id, dependency.param_name))
+            continue
+        service_node_id = _node_id(dependency.service_id, dependency.qualifier)
+        if service_node_id in service_nodes:
+            edge_refs.add((service_node_id, target_node_id, dependency.param_name))
+
+
+def _groups_for_nodes(nodes: tuple[GraphNode, ...]) -> tuple[GraphGroup, ...]:
+    groups: dict[str, GraphGroup] = {}
+    for node in nodes:
+        group_id = _group_id(node.group)
+        groups[group_id] = GraphGroup(
+            id=group_id,
+            label=node.group,
+            kind="group",
+            module=node.group,
+        )
+    return tuple(groups.values())
+
+
+def _service_node(
+    impl: type[Any],
+    qualifier: Qualifier | None,
+    factory: InjectableFactory,
+    lifetime: str,
+    base_module: str | None,
+) -> GraphNode:
+    is_factory = not isinstance(factory.factory, type)
+    label_prefix = "🏭" if is_factory else "🐍"
+    label = f"{label_prefix} {impl.__name__}"
+    if qualifier is not None:
+        label = f"{label} [{qualifier}]"
+
+    module_name = factory.factory.__module__
+    group = _display_module_name(module_name, base_module)
+    parent = _group_id(group)
+    return GraphNode(
+        id=_node_id(f"{impl.__module__}.{impl.__qualname__}", qualifier),
+        label=label,
+        kind="factory" if is_factory else "service",
+        lifetime=lifetime,
+        module=module_name,
+        parent=parent,
+        original_parent=parent,
+        group=group,
+        factory_name=None if not is_factory else factory.factory.__name__,
+    )
+
+
+def _config_node(config_key: str) -> GraphNode:
+    group = "Configuration"
+    parent = _group_id(group)
+    return GraphNode(
+        id=_node_id(f"config.{config_key}", None),
+        label=f"⚙️ {config_key}",
+        kind="config",
+        lifetime=None,
+        module="config",
+        parent=parent,
+        original_parent=parent,
+        group=group,
+        factory_name=None,
+    )
+
+
+def _consumer_node(consumer: ConsumerRecord) -> GraphNode:
+    parent = _group_id(consumer.group)
+    return GraphNode(
+        id=_node_id(f"consumer.{consumer.id}", None),
+        label=consumer.label,
+        kind="consumer",
+        lifetime=None,
+        module=consumer.module,
+        parent=parent,
+        original_parent=parent,
+        group=consumer.group,
+        factory_name=None,
+    )
+
+
+def _sort_obj_id(obj_id: ContainerObjectIdentifier) -> tuple[str, str]:
+    impl, qualifier = _split_obj_id(obj_id)
+    return (f"{impl.__module__}.{impl.__qualname__}", "" if qualifier is None else str(qualifier))
+
+
+def _split_obj_id(obj_id: ContainerObjectIdentifier) -> tuple[type[Any], Qualifier | None]:
+    return obj_id if isinstance(obj_id, tuple) else (obj_id, None)
+
+
+def _node_id(name: str, qualifier: Qualifier | None) -> str:
+    raw = name if qualifier is None else f"{name}.{qualifier}"
+    sanitized = re.sub(r"\W+", "_", raw).strip("_")
+    if not sanitized:
+        return "node"
+    if sanitized[0].isdigit():
+        return f"n_{sanitized}"
+    return sanitized
+
+
+def _group_id(group_name: str) -> str:
+    return f"group_{_node_id(group_name, None)}"
+
+
+def _display_module_name(module_name: str, base_module: str | None) -> str:
+    if not base_module:
+        return module_name
+
+    normalized_base = base_module.rstrip(".")
+    if module_name == normalized_base:
+        return normalized_base.split(".")[-1]
+
+    prefix = f"{normalized_base}."
+    if module_name.startswith(prefix):
+        return module_name[len(prefix) :]
+
+    return module_name

--- a/wireup/renderer/full_page.py
+++ b/wireup/renderer/full_page.py
@@ -1,0 +1,1719 @@
+from __future__ import annotations
+
+import json
+from dataclasses import asdict, dataclass
+from typing import TYPE_CHECKING
+
+from wireup.renderer.core import GraphData, GraphOptions, to_graph_data
+
+__all__ = [
+    "GraphEndpointOptions",
+    "GraphOptions",
+    "full_page_renderer",
+    "render_graph_page",
+    "to_graph_data",
+]
+
+if TYPE_CHECKING:
+    from wireup.ioc.container.base_container import BaseContainer
+
+
+@dataclass(frozen=True)
+class GraphEndpointOptions:
+    base_module: str | None = None
+
+_TITLE_PLACEHOLDER = "__WIREUP_TITLE__"
+_GRAPH_DATA_PLACEHOLDER = "__WIREUP_GRAPH_DATA__"
+_FULL_PAGE_TEMPLATE = """<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>__WIREUP_TITLE__</title>
+  <script>
+    (() => {
+      const storageKey = `wireup:theme:${document.title || "wireup-graph"}`;
+      const storedTheme = window.localStorage.getItem(storageKey);
+      const theme = storedTheme === "light" || storedTheme === "dark" ? storedTheme : "dark";
+      document.documentElement.setAttribute("data-theme", theme);
+    })();
+  </script>
+  <style>
+    :root {
+      --font-ui: "Inter", "Segoe UI", sans-serif;
+      --font-display: "Space Grotesk", "Segoe UI", sans-serif;
+      --radius-lg: 18px;
+      --radius-md: 12px;
+      --radius-sm: 10px;
+      --shadow: 0 24px 60px rgba(0, 0, 0, 0.24);
+      --bg: #0f1321;
+      --bg-elevated: #151a2b;
+      --bg-panel: #1b2134;
+      --bg-panel-soft: #232940;
+      --bg-canvas: #0c1020;
+      --ink: #edf1ff;
+      --muted: #8f97b4;
+      --line: rgba(151, 161, 198, 0.18);
+      --line-strong: rgba(151, 161, 198, 0.28);
+      --accent: #ff3d7f;
+      --accent-soft: rgba(255, 61, 127, 0.16);
+      --accent-strong: #36d2ff;
+      --service: #2a3552;
+      --factory: #243c56;
+      --consumer: #2f314f;
+      --config: #47305d;
+      --group: #1a2237;
+      --edge: #69718c;
+      --edge-strong: #8a93b3;
+      --detail-bg: rgba(18, 23, 38, 0.96);
+      --pill-bg: rgba(255, 255, 255, 0.04);
+      --button-bg: rgba(255, 255, 255, 0.06);
+      --button-bg-hover: rgba(255, 255, 255, 0.11);
+      --node-text: #edf1ff;
+      --panel-blur: blur(18px);
+    }
+
+    html[data-theme="light"] body {
+      --shadow: 0 22px 54px rgba(46, 55, 80, 0.16);
+      --bg: #eef2fb;
+      --bg-elevated: #f7f9ff;
+      --bg-panel: rgba(255, 255, 255, 0.92);
+      --bg-panel-soft: #f2f5ff;
+      --bg-canvas: #f8faff;
+      --ink: #1b2234;
+      --muted: #68728f;
+      --line: rgba(84, 97, 132, 0.14);
+      --line-strong: rgba(84, 97, 132, 0.24);
+      --accent: #d61d61;
+      --accent-soft: rgba(214, 29, 97, 0.12);
+      --accent-strong: #0f8db3;
+      --service: #e7eeff;
+      --factory: #e0efff;
+      --consumer: #e9e5ff;
+      --config: #f1e5ff;
+      --group: #e7ebf5;
+      --edge: #7a859f;
+      --edge-strong: #58637f;
+      --detail-bg: rgba(255, 255, 255, 0.97);
+      --pill-bg: rgba(27, 34, 52, 0.04);
+      --button-bg: rgba(27, 34, 52, 0.05);
+      --button-bg-hover: rgba(27, 34, 52, 0.09);
+      --node-text: #1b2234;
+    }
+
+    * {
+      box-sizing: border-box;
+    }
+
+    html,
+    body {
+      margin: 0;
+      min-height: 100%;
+      font-family: var(--font-ui);
+      background:
+        radial-gradient(circle at top left, rgba(255, 61, 127, 0.16), transparent 22%),
+        radial-gradient(circle at top right, rgba(54, 210, 255, 0.12), transparent 20%),
+        linear-gradient(180deg, var(--bg-elevated) 0%, var(--bg) 100%);
+      color: var(--ink);
+    }
+
+    body {
+      color-scheme: dark;
+    }
+
+    html[data-theme="light"] body {
+      color-scheme: light;
+    }
+
+    button,
+    input,
+    select {
+      font: inherit;
+    }
+
+    .app-shell {
+      min-height: 100vh;
+      display: grid;
+      grid-template-rows: 58px 1fr;
+    }
+
+    .panel {
+      background: var(--bg-panel);
+      border: 1px solid var(--line);
+      border-radius: var(--radius-lg);
+      box-shadow: var(--shadow);
+      backdrop-filter: var(--panel-blur);
+    }
+
+    .topbar {
+      display: grid;
+      grid-template-columns: auto minmax(0, 1fr) auto;
+      gap: 14px;
+      align-items: center;
+      padding: 0 18px;
+      border-bottom: 1px solid var(--line);
+      background: rgba(13, 18, 31, 0.72);
+      backdrop-filter: blur(18px);
+      position: sticky;
+      top: 0;
+      z-index: 10;
+    }
+
+    html[data-theme="light"] .topbar {
+      background: rgba(245, 248, 255, 0.88);
+    }
+
+    .brand {
+      display: inline-flex;
+      align-items: center;
+      min-width: 0;
+      font-family: var(--font-display);
+      font-weight: 700;
+      letter-spacing: 0.04em;
+      text-transform: uppercase;
+      color: var(--ink);
+    }
+
+    .topbar-title {
+      min-width: 0;
+      display: inline-flex;
+      align-items: center;
+      gap: 10px;
+      padding: 10px 14px;
+      border-radius: var(--radius-sm);
+      border: 1px solid var(--line-strong);
+      background: var(--button-bg);
+      color: var(--ink);
+      overflow: hidden;
+    }
+
+    .topbar-title::before {
+      content: "";
+      width: 8px;
+      height: 8px;
+      border-radius: 999px;
+      background: #3ddc97;
+      box-shadow: 0 0 12px rgba(61, 220, 151, 0.7);
+      flex: 0 0 auto;
+    }
+
+    .topbar-title span {
+      overflow: hidden;
+      text-overflow: ellipsis;
+      white-space: nowrap;
+    }
+
+    .topbar-actions {
+      display: inline-flex;
+      align-items: center;
+      gap: 10px;
+      justify-self: end;
+    }
+
+    .button,
+    .details-pill {
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      gap: 8px;
+      min-height: 40px;
+      border-radius: var(--radius-sm);
+      border: 1px solid var(--line-strong);
+      background: var(--button-bg);
+      color: var(--ink);
+      cursor: pointer;
+      transition: background 120ms ease, border-color 120ms ease, transform 120ms ease;
+    }
+
+    .button {
+      padding: 0 14px;
+      font-size: 0.78rem;
+      font-weight: 700;
+      letter-spacing: 0.05em;
+      text-transform: uppercase;
+    }
+
+    .button:hover,
+    .details-pill:hover {
+      background: var(--button-bg-hover);
+      border-color: rgba(255, 61, 127, 0.38);
+    }
+
+    .button-accent {
+      color: #ff6f9d;
+      border-color: rgba(255, 61, 127, 0.38);
+      box-shadow: inset 0 0 0 1px rgba(255, 61, 127, 0.08);
+    }
+
+    .controls-menu {
+      position: relative;
+    }
+
+    .controls-panel {
+      position: absolute;
+      top: calc(100% + 10px);
+      right: 0;
+      width: min(280px, calc(100vw - 32px));
+      padding: 12px;
+      border-radius: 14px;
+      border: 1px solid var(--line-strong);
+      background: var(--detail-bg);
+      box-shadow: var(--shadow);
+      display: grid;
+      gap: 10px;
+      z-index: 20;
+    }
+
+    .controls-panel[hidden] {
+      display: none;
+    }
+
+    .controls-section-title {
+      margin: 2px 2px -2px;
+      font-size: 0.7rem;
+      font-weight: 800;
+      letter-spacing: 0.14em;
+      text-transform: uppercase;
+      color: var(--muted);
+    }
+
+    .controls-panel .button {
+      width: 100%;
+      justify-content: flex-start;
+      text-transform: none;
+      letter-spacing: 0.02em;
+      font-size: 0.86rem;
+      font-weight: 600;
+    }
+
+    .workspace {
+      min-height: 0;
+      display: grid;
+      grid-template-columns: 332px minmax(0, 1fr);
+    }
+
+    .sidebar {
+      padding: 20px;
+      border-right: 1px solid var(--line);
+      background: rgba(18, 22, 37, 0.82);
+      display: grid;
+      grid-template-rows: auto auto minmax(0, 1fr);
+      gap: 18px;
+      min-height: 0;
+    }
+
+    html[data-theme="light"] .sidebar {
+      background: rgba(248, 250, 255, 0.92);
+    }
+
+    .sidebar-section {
+      border-bottom: 1px solid var(--line);
+      padding-bottom: 18px;
+    }
+
+    .sidebar-section:last-child {
+      border-bottom: 0;
+      padding-bottom: 0;
+      min-height: 0;
+      display: grid;
+      grid-template-rows: auto auto 1fr;
+    }
+
+    .eyebrow {
+      margin: 0 0 10px;
+      font-size: 0.72rem;
+      font-weight: 800;
+      letter-spacing: 0.16em;
+      text-transform: uppercase;
+      color: var(--muted);
+    }
+
+    .sidebar-text {
+      margin: 10px 0 0;
+      line-height: 1.6;
+      color: var(--muted);
+    }
+
+    .field,
+    .group {
+      display: flex;
+      flex-direction: column;
+      gap: 8px;
+      min-width: 0;
+    }
+
+    .field label,
+    .group .label {
+      font-size: 0.72rem;
+      font-weight: 800;
+      text-transform: uppercase;
+      letter-spacing: 0.12em;
+      color: var(--muted);
+    }
+
+    input[type="search"] {
+      width: 100%;
+      border: 1px solid var(--line-strong);
+      background: var(--bg-panel-soft);
+      border-radius: var(--radius-sm);
+      padding: 12px 14px;
+      color: var(--ink);
+    }
+
+    select {
+      width: 100%;
+      border: 1px solid var(--line-strong);
+      background: var(--bg-panel-soft);
+      border-radius: var(--radius-sm);
+      padding: 12px 14px;
+      color: var(--ink);
+    }
+
+    .toggle-list,
+    .legend-list {
+      display: grid;
+      gap: 10px;
+    }
+
+    .toggle,
+    .legend-pill {
+      display: inline-flex;
+      align-items: flex-start;
+      gap: 8px;
+      min-height: 40px;
+      font-size: 0.92rem;
+      line-height: 1.35;
+      border: 1px solid var(--line-strong);
+      border-radius: var(--radius-sm);
+      padding: 9px 12px;
+      background: var(--pill-bg);
+    }
+
+    .legend-copy {
+      display: grid;
+      gap: 2px;
+      min-width: 0;
+    }
+
+    .legend-title {
+      font-weight: 600;
+      color: var(--ink);
+    }
+
+    .legend-title[data-tooltip] {
+      cursor: help;
+    }
+
+    .legend-description {
+      font-size: 0.9rem;
+      color: var(--muted);
+    }
+
+    .toggle input {
+      accent-color: var(--accent);
+      margin: 2px 0 0;
+    }
+
+    .toggle-copy {
+      display: grid;
+      gap: 2px;
+      min-width: 0;
+    }
+
+    .toggle-title {
+      font-weight: 600;
+      color: var(--ink);
+    }
+
+    .toggle-description {
+      font-size: 0.9rem;
+      color: var(--muted);
+    }
+
+    .legend-pill.service {
+      background: var(--service);
+    }
+
+    .legend-pill.factory {
+      background: var(--factory);
+    }
+
+    .legend-pill.consumer {
+      background: var(--consumer);
+    }
+
+    .legend-pill.config {
+      background: var(--config);
+    }
+
+    .legend-pill.lifetime {
+      border-color: var(--line-strong);
+      border-width: 2px;
+    }
+
+    .legend-pill.singleton {
+      border-style: solid;
+    }
+
+    .legend-pill.scoped {
+      border-style: dashed;
+    }
+
+    .legend-pill.transient {
+      border-style: dotted;
+    }
+
+    .viewer {
+      position: relative;
+      min-height: 0;
+      background:
+        radial-gradient(circle at 18% 18%, rgba(54, 210, 255, 0.08), transparent 20%),
+        radial-gradient(circle at 74% 16%, rgba(255, 61, 127, 0.07), transparent 22%),
+        linear-gradient(180deg, rgba(255, 255, 255, 0.01), transparent 42%),
+        var(--bg-canvas);
+      overflow: hidden;
+    }
+
+    #cy {
+      position: absolute;
+      inset: 0;
+    }
+
+    .details {
+      position: absolute;
+      right: 20px;
+      bottom: 20px;
+      width: min(380px, calc(100% - 40px));
+      padding: 18px;
+      border-radius: 16px;
+      border: 1px solid var(--line-strong);
+      background: var(--detail-bg);
+      box-shadow: var(--shadow);
+      z-index: 2;
+    }
+
+    .details h2 {
+      margin: 0 0 8px;
+      font-family: var(--font-display);
+      font-size: 1.08rem;
+    }
+
+    .details-subtitle {
+      margin: 0 0 12px;
+      font-size: 0.9rem;
+      color: var(--muted);
+    }
+
+    .details-empty {
+      margin: 0;
+      font-size: 0.9rem;
+      color: var(--muted);
+    }
+
+    .details-kind-box {
+      width: 12px;
+      height: 12px;
+      border-radius: 3px;
+      border: 1px solid rgba(0, 0, 0, 0.12);
+      flex: 0 0 auto;
+    }
+
+    .details-legend {
+      display: grid;
+      gap: 6px;
+      margin: 0 0 10px;
+      font-size: 0.82rem;
+      color: var(--muted);
+    }
+
+    .details-legend-item {
+      display: flex;
+      align-items: center;
+      gap: 6px;
+    }
+
+    .details-section {
+      margin: 0 0 12px;
+    }
+
+    .details-section-title {
+      margin: 0 0 6px;
+      font-size: 0.78rem;
+      font-weight: 700;
+      letter-spacing: 0.04em;
+      text-transform: uppercase;
+      color: var(--muted);
+    }
+
+    .details-pills {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 6px;
+      min-height: 28px;
+    }
+
+    .details-pill {
+      align-items: center;
+      gap: 6px;
+      min-width: 0;
+      font-size: 0.82rem;
+      line-height: 1.2;
+      padding: 0 12px;
+    }
+
+    .details-pill.empty {
+      color: var(--muted);
+      cursor: default;
+      background: var(--button-bg);
+    }
+
+    .details-pill.empty:hover {
+      border-color: var(--line-strong);
+    }
+
+    .details-pill-swatch {
+      width: 10px;
+      height: 10px;
+      border-radius: 999px;
+      flex: 0 0 auto;
+    }
+
+    .details dl {
+      margin: 0;
+      display: grid;
+      grid-template-columns: max-content minmax(0, 1fr);
+      gap: 8px 10px;
+      font-size: 0.9rem;
+    }
+
+    .details dt {
+      color: var(--muted);
+      white-space: nowrap;
+    }
+
+    .details dd {
+      margin: 0;
+      overflow-wrap: anywhere;
+      word-break: break-word;
+    }
+
+    .details-meta-code {
+      font-size: 0.84rem;
+      line-height: 1.35;
+      color: var(--muted);
+      font-family: "IBM Plex Mono", "SFMono-Regular", monospace;
+    }
+
+    .details-value {
+      display: inline-flex;
+      align-items: center;
+      gap: 8px;
+      min-width: 0;
+    }
+
+    .theme-button .theme-button-light,
+    html[data-theme="light"] .theme-button .theme-button-dark {
+      display: inline;
+    }
+
+    .theme-button .theme-button-dark,
+    html[data-theme="light"] .theme-button .theme-button-light {
+      display: none;
+    }
+
+    @media (max-width: 980px) {
+      .topbar {
+        grid-template-columns: 1fr;
+        padding: 14px;
+      }
+
+      .workspace {
+        grid-template-columns: 1fr;
+      }
+
+      .sidebar {
+        border-right: 0;
+        border-bottom: 1px solid var(--line);
+      }
+
+      .details {
+        position: static;
+        width: auto;
+        margin: 20px;
+      }
+
+      .controls-panel {
+        position: fixed;
+        top: 72px;
+        right: 16px;
+      }
+    }
+  </style>
+</head>
+<body>
+  <div class="app-shell">
+    <header class="topbar">
+      <div class="brand">
+        <span>Wireup Graph</span>
+      </div>
+
+      <div class="topbar-title">
+        <span>__WIREUP_TITLE__</span>
+      </div>
+
+      <div class="topbar-actions">
+        <div class="controls-menu">
+          <button
+            class="button"
+            id="controls-toggle"
+            type="button"
+            aria-expanded="false"
+            aria-controls="controls-panel"
+          >
+            Controls
+          </button>
+          <div class="controls-panel" id="controls-panel" hidden>
+            <div class="controls-section-title">View</div>
+            <button class="button theme-button" id="theme-toggle" type="button">
+              <span class="theme-button-light">Switch to Light Mode</span>
+              <span class="theme-button-dark">Switch to Dark Mode</span>
+            </button>
+            <div class="controls-section-title">Layout</div>
+            <button class="button" id="reset-layout" type="button">Reset Layout</button>
+            <button class="button" id="reset-viewport" type="button">Reset Zoom</button>
+            <div class="controls-section-title">Export</div>
+            <button class="button button-accent" id="export-png" type="button">Export as PNG</button>
+          </div>
+        </div>
+      </div>
+    </header>
+
+    <div class="workspace">
+      <aside class="sidebar">
+        <section class="sidebar-section">
+          <div class="field">
+            <label for="search">Filter nodes</label>
+            <input id="search" type="search" placeholder="PetCatalogService, adoption, request">
+          </div>
+          <div class="field" style="margin-top: 14px;">
+            <label for="layout-mode">Layout</label>
+            <select id="layout-mode" aria-label="Graph layout">
+              <option value="dagre">Dependency flow</option>
+              <option value="elk">Layered</option>
+              <option value="grid">Grid</option>
+              <option value="circle">Circle</option>
+              <option value="concentric">Concentric</option>
+              <option value="breadthfirst">Classic</option>
+            </select>
+          </div>
+          <p class="sidebar-text">
+            Explore services, factories, configuration, routes, and functions from a single graph view.
+          </p>
+        </section>
+
+        <section class="sidebar-section">
+          <p class="eyebrow">Options</p>
+          <div class="toggle-list">
+            <label class="toggle">
+              <input id="toggle-config" type="checkbox" checked>
+              <span class="toggle-copy">
+                <span class="toggle-title">Show configuration nodes</span>
+                <span class="toggle-description">Display config entries that feed the selected graph.</span>
+              </span>
+            </label>
+            <label class="toggle">
+              <input id="toggle-edge-labels" type="checkbox" checked>
+              <span class="toggle-copy">
+                <span class="toggle-title">Show edge labels</span>
+                <span class="toggle-description">Reveal parameter names on dependency connections.</span>
+              </span>
+            </label>
+            <label class="toggle">
+              <input id="toggle-modules" type="checkbox" checked>
+              <span class="toggle-copy">
+                <span class="toggle-title">Group by modules</span>
+                <span class="toggle-description">Cluster related nodes inside their source module groups.</span>
+              </span>
+            </label>
+            <label class="toggle">
+              <input id="toggle-empty-groups" type="checkbox" checked>
+              <span class="toggle-copy">
+                <span class="toggle-title">Include unused groups</span>
+                <span class="toggle-description">Keep empty module containers visible in the overview.</span>
+              </span>
+            </label>
+          </div>
+
+          <p class="eyebrow" style="margin-top:18px;">Legend</p>
+          <div class="legend-list" id="legend-list">
+            <span class="legend-pill lifetime singleton">Singleton</span>
+            <span class="legend-pill lifetime scoped">Scoped</span>
+            <span class="legend-pill lifetime transient">Transient</span>
+          </div>
+        </section>
+      </aside>
+
+      <section class="viewer">
+        <div id="cy"></div>
+        <section class="details" id="details">
+          <h2>No node selected</h2>
+          <p class="details-empty">Left click for the full neighborhood. Right click for dependency paths only.</p>
+        </section>
+      </section>
+    </div>
+  </div>
+
+  <script id="wireup-graph-data" type="application/json">__WIREUP_GRAPH_DATA__</script>
+  <script src="https://cdn.jsdelivr.net/npm/cytoscape@3.30.2/dist/cytoscape.min.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/dagre@0.8.5/dist/dagre.min.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/cytoscape-dagre@2.5.0/cytoscape-dagre.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/elkjs@0.10.0/lib/elk.bundled.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/cytoscape-elk@2.3.0/dist/cytoscape-elk.js"></script>
+  <script>
+    const VIEWPORT_PADDING = 100;
+    const GRID_SIZE = 24;
+    if (typeof cytoscapeDagre === "function") {
+      cytoscape.use(cytoscapeDagre);
+    }
+    if (typeof cytoscapeElk === "function") {
+      cytoscape.use(cytoscapeElk);
+    }
+    const graphData = JSON.parse(document.getElementById("wireup-graph-data").textContent);
+    const legendList = document.getElementById("legend-list");
+    const search = document.getElementById("search");
+    const layoutMode = document.getElementById("layout-mode");
+    const toggleConfig = document.getElementById("toggle-config");
+    const toggleEdgeLabels = document.getElementById("toggle-edge-labels");
+    const toggleModules = document.getElementById("toggle-modules");
+    const toggleEmptyGroups = document.getElementById("toggle-empty-groups");
+    const controlsToggleButton = document.getElementById("controls-toggle");
+    const controlsPanel = document.getElementById("controls-panel");
+    const resetLayoutButton = document.getElementById("reset-layout");
+    const resetViewportButton = document.getElementById("reset-viewport");
+    const exportPngButton = document.getElementById("export-png");
+    const themeToggleButton = document.getElementById("theme-toggle");
+    const availableLayouts = new Set(["breadthfirst", "grid", "circle", "concentric", "dagre", "elk"]);
+    const hasDagreLayout = typeof cytoscape("layout", "dagre") === "function";
+    const hasElkLayout = typeof cytoscape("layout", "elk") === "function";
+
+    if (!availableLayouts.has(layoutMode.value) && layoutMode.options.length > 0) {
+      layoutMode.value = layoutMode.options[0].value;
+    }
+
+    function getInitialLayoutName() {
+      if (hasDagreLayout) {
+        return "dagre";
+      }
+      if (hasElkLayout) {
+        return "elk";
+      }
+      return "breadthfirst";
+    }
+
+    function buildLegendItem(className, title, description, showDescription = false) {
+      const escapedDescription = escapeHtml(description);
+      const titleMarkup = showDescription
+        ? `<span class="legend-title">${title}</span>`
+        : (
+            `<span class="legend-title" data-tooltip="${escapedDescription}" title="${escapedDescription}">` +
+            `${title}</span>`
+          );
+      const descriptionMarkup = showDescription
+        ? `<span class="legend-description">${description}</span>`
+        : "";
+
+      return (
+        `<span class="legend-pill ${className}">` +
+        `<span class="legend-copy">` +
+        titleMarkup +
+        descriptionMarkup +
+        `</span>` +
+        `</span>`
+      );
+    }
+
+    function getConsumerLegendKinds() {
+      const consumerNodes = graphData.nodes.filter((node) => node.kind === "consumer");
+      const hasRoute = consumerNodes.some((node) => String(node.label || "").startsWith("🌐 "));
+      const hasFunction = consumerNodes.some((node) => String(node.label || "").startsWith("ƒ "));
+
+      return { hasRoute, hasFunction };
+    }
+
+    function renderLegend() {
+      const staticLegend = [
+        buildLegendItem("lifetime singleton", "Singleton", "Shared across the whole container."),
+        buildLegendItem("lifetime scoped", "Scoped", "Created once per active request or scope."),
+        buildLegendItem("lifetime transient", "Transient", "Created fresh for each injection."),
+      ];
+      const kinds = new Set(graphData.nodes.map((node) => node.kind));
+      const dynamicLegend = [];
+      const consumerKinds = getConsumerLegendKinds();
+
+      if (kinds.has("consumer") && consumerKinds.hasFunction) {
+        dynamicLegend.push(buildLegendItem("consumer", "ƒ Function", "Injected callables discovered outside routes."));
+      }
+      if (kinds.has("consumer") && consumerKinds.hasRoute) {
+        dynamicLegend.push(buildLegendItem("consumer", "🌐 Route", "Framework entrypoints that request dependencies."));
+      }
+      if (kinds.has("service")) {
+        dynamicLegend.push(
+          buildLegendItem("service", "🐍 Class injectable", "Registered classes resolved from the container.")
+        );
+      }
+      if (kinds.has("config")) {
+        dynamicLegend.push(
+          buildLegendItem("config", "⚙️ Configuration", "Config values injected into services or functions.")
+        );
+      }
+      if (kinds.has("factory")) {
+        dynamicLegend.push(
+          buildLegendItem("factory", "🏭 Factory", "Factory providers that create dependency instances.")
+        );
+      }
+
+      legendList.innerHTML = `${dynamicLegend.join("")}${staticLegend.join("")}`;
+    }
+
+    function getBootLayoutConfig() {
+      const initialLayout = getInitialLayoutName();
+
+      if (initialLayout === "dagre") {
+        return {
+          name: "dagre",
+          rankDir: "LR",
+          padding: VIEWPORT_PADDING,
+          spacingFactor: 1.1,
+          nodeSep: 40,
+          rankSep: 84
+        };
+      }
+
+      if (initialLayout === "elk") {
+        return {
+          name: "elk",
+          fit: true,
+          animate: false,
+          padding: VIEWPORT_PADDING,
+          elk: {
+            algorithm: "layered",
+            "elk.direction": "RIGHT",
+            "elk.layered.spacing.nodeNodeBetweenLayers": "90",
+            "elk.spacing.nodeNode": "36",
+            "elk.edgeRouting": "ORTHOGONAL"
+          }
+        };
+      }
+
+      return {
+        name: "breadthfirst",
+        directed: true,
+        padding: VIEWPORT_PADDING,
+        spacingFactor: 1.15,
+        animate: false,
+        fit: true
+      };
+    }
+
+    const nodeParentById = Object.fromEntries(
+      graphData.nodes.map((node) => [node.id, node.original_parent || node.parent || null])
+    );
+    const aggregateEdges = (() => {
+      const groupedEdges = new Map();
+
+      graphData.edges.forEach((edge) => {
+        const sourceParent = nodeParentById[edge.source];
+        const targetParent = nodeParentById[edge.target];
+        if (!sourceParent || !targetParent || sourceParent === targetParent) {
+          return;
+        }
+
+        const key = `${sourceParent}->${targetParent}`;
+        if (groupedEdges.has(key)) {
+          return;
+        }
+
+        groupedEdges.set(key, {
+          id: `aggregate_${groupedEdges.size}`,
+          source: sourceParent,
+          target: targetParent,
+          label: "",
+          kind: "aggregate"
+        });
+      });
+
+      return [...groupedEdges.values()];
+    })();
+    const elements = [
+      ...graphData.groups.map((group) => ({ data: group })),
+      ...graphData.nodes.map((node) => ({ data: node })),
+      ...graphData.edges.map((edge) => ({ data: edge })),
+      ...aggregateEdges.map((edge) => ({ data: edge }))
+    ];
+
+    const cy = cytoscape({
+      container: document.getElementById("cy"),
+      elements,
+      layout: getBootLayoutConfig(),
+      wheelSensitivity: 0.15,
+      style: []
+    });
+
+    const details = document.getElementById("details");
+    const cyContainer = document.getElementById("cy");
+
+    let activeNodeId = null;
+
+    function getStoragePrefix() {
+      return `wireup:positions:${document.title || "wireup-graph"}`;
+    }
+
+    function getStorageKey() {
+      return `${getStoragePrefix()}:${layoutMode.value}:${toggleModules.checked ? "modules" : "flat"}`;
+    }
+
+    function getThemeStorageKey() {
+      return `wireup:theme:${document.title || "wireup-graph"}`;
+    }
+
+    function getLayoutStorageKey() {
+      return `wireup:layout:${document.title || "wireup-graph"}`;
+    }
+
+    function readCssVar(name) {
+      return getComputedStyle(document.body).getPropertyValue(name).trim();
+    }
+
+    function applyTheme(theme) {
+      document.documentElement.setAttribute("data-theme", theme);
+      window.localStorage.setItem(getThemeStorageKey(), theme);
+      applyCytoscapeTheme();
+    }
+
+    function setControlsOpen(isOpen) {
+      controlsPanel.hidden = !isOpen;
+      controlsToggleButton.setAttribute("aria-expanded", isOpen ? "true" : "false");
+    }
+
+    function applyCytoscapeTheme() {
+      const ink = readCssVar("--node-text");
+      const lineStrong = readCssVar("--line-strong");
+      const edge = readCssVar("--edge");
+      const edgeStrong = readCssVar("--edge-strong");
+      const service = readCssVar("--service");
+      const factory = readCssVar("--factory");
+      const consumer = readCssVar("--consumer");
+      const config = readCssVar("--config");
+      const group = readCssVar("--group");
+      const accent = readCssVar("--accent");
+      const dependencyHighlight = "#36d2ff";
+      const dependantHighlight = "#ffb02e";
+      const edgeLabelBackground = (
+        document.documentElement.getAttribute("data-theme") === "light" ? "#ffffff" : "#1b2134"
+      );
+
+      cy.style([
+        {
+          selector: "node",
+          style: {
+            "label": "data(label)",
+            "text-wrap": "wrap",
+            "text-max-width": 240,
+            "font-family": "Inter, Segoe UI, sans-serif",
+            "font-size": 13,
+            "text-valign": "center",
+            "text-halign": "center",
+            "border-width": 1.2,
+            "border-style": "solid",
+            "border-color": lineStrong,
+            "color": ink
+          }
+        },
+        {
+          selector: 'node[lifetime = "scoped"]',
+          style: {
+            "border-style": "dashed"
+          }
+        },
+        {
+          selector: 'node[lifetime = "transient"]',
+          style: {
+            "border-style": "dotted"
+          }
+        },
+        {
+          selector: 'node[kind = "service"]',
+          style: {
+            "shape": "round-rectangle",
+            "width": 220,
+            "height": 58,
+            "background-color": service
+          }
+        },
+        {
+          selector: 'node[kind = "factory"]',
+          style: {
+            "shape": "round-rectangle",
+            "width": 228,
+            "height": 64,
+            "background-color": factory
+          }
+        },
+        {
+          selector: 'node[kind = "consumer"]',
+          style: {
+            "shape": "round-rectangle",
+            "width": 260,
+            "height": 58,
+            "background-color": consumer
+          }
+        },
+        {
+          selector: 'node[kind = "config"]',
+          style: {
+            "shape": "round-rectangle",
+            "width": 118,
+            "height": 44,
+            "background-color": config
+          }
+        },
+        {
+          selector: 'node[kind = "group"]',
+          style: {
+            "shape": "round-rectangle",
+            "padding": "26px",
+            "font-weight": 700,
+            "font-size": 15,
+            "text-valign": "top",
+            "text-halign": "center",
+            "background-color": group,
+            "border-style": "solid",
+            "border-color": lineStrong,
+            "color": ink
+          }
+        },
+        {
+          selector: "$node > node",
+          style: {
+            "text-margin-y": -12
+          }
+        },
+        {
+          selector: "edge",
+          style: {
+            "curve-style": "bezier",
+            "width": 1.7,
+            "line-color": edge,
+            "target-arrow-color": edge,
+            "target-arrow-shape": "triangle",
+            "arrow-scale": 0.85,
+            "label": "data(display_label)",
+            "font-size": 10,
+            "text-background-color": edgeLabelBackground,
+            "text-background-opacity": 0.94,
+            "text-background-padding": 3,
+            "color": ink
+          }
+        },
+        {
+          selector: 'edge[kind = "aggregate"]',
+          style: {
+            "width": 2.2,
+            "line-color": edgeStrong,
+            "target-arrow-color": edgeStrong
+          }
+        },
+        {
+          selector: ".dimmed",
+          style: {
+            "opacity": 0.1
+          }
+        },
+        {
+          selector: ".highlight-selected",
+          style: {
+            "border-color": accent,
+            "border-width": 2.4,
+            "opacity": 1
+          }
+        },
+        {
+          selector: ".highlight-dependency",
+          style: {
+            "border-color": dependencyHighlight,
+            "opacity": 1
+          }
+        },
+        {
+          selector: ".highlight-dependant",
+          style: {
+            "border-color": dependantHighlight,
+            "opacity": 1
+          }
+        },
+        {
+          selector: ".hidden",
+          style: {
+            "display": "none"
+          }
+        }
+      ]).update();
+    }
+
+    function savePositions() {
+      const positions = {};
+      cy.nodes().forEach((node) => {
+        positions[node.id()] = node.position();
+      });
+      window.localStorage.setItem(getStorageKey(), JSON.stringify(positions));
+    }
+
+    function snapValue(value) {
+      return Math.round(value / GRID_SIZE) * GRID_SIZE;
+    }
+
+    function snapPosition(position) {
+      return {
+        x: snapValue(position.x),
+        y: snapValue(position.y)
+      };
+    }
+
+    function snapNodeToGrid(node) {
+      node.position(snapPosition(node.position()));
+    }
+
+    function clearStoredPositions() {
+      const prefix = `${getStoragePrefix()}:`;
+      const keysToRemove = [];
+
+      for (let index = 0; index < window.localStorage.length; index += 1) {
+        const key = window.localStorage.key(index);
+        if (key && key.startsWith(prefix)) {
+          keysToRemove.push(key);
+        }
+      }
+
+      keysToRemove.forEach((key) => {
+        window.localStorage.removeItem(key);
+      });
+    }
+
+    function restorePositions() {
+      const raw = window.localStorage.getItem(getStorageKey());
+      if (!raw) {
+        return false;
+      }
+
+      try {
+        const positions = JSON.parse(raw);
+        cy.batch(() => {
+          cy.nodes().forEach((node) => {
+            const position = positions[node.id()];
+            if (position && typeof position.x === "number" && typeof position.y === "number") {
+              node.position(snapPosition(position));
+            }
+          });
+        });
+        cy.fit(cy.elements(":visible"), VIEWPORT_PADDING);
+        return true;
+      } catch {
+        window.localStorage.removeItem(getStorageKey());
+        return false;
+      }
+    }
+
+    function getLayoutConfig() {
+      if (layoutMode.value === "dagre" && hasDagreLayout) {
+        return {
+          name: "dagre",
+          rankDir: "LR",
+          padding: VIEWPORT_PADDING,
+          spacingFactor: 1.1,
+          nodeSep: 40,
+          rankSep: 84,
+          animate: false,
+          fit: true
+        };
+      }
+
+      if (layoutMode.value === "elk" && hasElkLayout) {
+        return {
+          name: "elk",
+          fit: true,
+          animate: false,
+          padding: VIEWPORT_PADDING,
+          elk: {
+            algorithm: "layered",
+            "elk.direction": "RIGHT",
+            "elk.layered.spacing.nodeNodeBetweenLayers": "90",
+            "elk.spacing.nodeNode": "36",
+            "elk.edgeRouting": "ORTHOGONAL"
+          }
+        };
+      }
+
+      if (layoutMode.value === "grid") {
+        return {
+          name: "grid",
+          padding: VIEWPORT_PADDING,
+          avoidOverlap: true,
+          fit: true,
+          animate: false
+        };
+      }
+
+      if (layoutMode.value === "circle") {
+        return {
+          name: "circle",
+          padding: VIEWPORT_PADDING,
+          fit: true,
+          animate: false
+        };
+      }
+
+      if (layoutMode.value === "concentric") {
+        return {
+          name: "concentric",
+          padding: VIEWPORT_PADDING,
+          fit: true,
+          animate: false,
+          avoidOverlap: true,
+          minNodeSpacing: 28
+        };
+      }
+
+      return {
+        name: "breadthfirst",
+        directed: true,
+        padding: VIEWPORT_PADDING,
+        spacingFactor: 1.15,
+        animate: false,
+        fit: true
+      };
+    }
+
+    function rerunLayout() {
+      window.localStorage.setItem(getLayoutStorageKey(), layoutMode.value);
+      const layout = cy.layout(getLayoutConfig());
+      layout.one("layoutstop", () => {
+        cy.batch(() => {
+          cy.nodes().forEach((node) => {
+            if (node.data("kind") !== "group") {
+              snapNodeToGrid(node);
+            }
+          });
+        });
+        savePositions();
+      });
+      layout.run();
+    }
+
+    function isAggregateOverview() {
+      return toggleModules.checked && activeNodeId === null;
+    }
+
+    function applyModuleOrganization() {
+      cy.batch(() => {
+        cy.nodes().forEach((node) => {
+          if (node.data("kind") === "group") {
+            return;
+          }
+
+          const originalParent = node.data("original_parent") || null;
+          const currentParent = node.parent().length ? node.parent().id() : null;
+          if (toggleModules.checked) {
+            if (originalParent && currentParent !== originalParent) {
+              node.move({ parent: originalParent });
+            }
+          } else if (currentParent !== null) {
+            node.move({ parent: null });
+          }
+        });
+      });
+    }
+
+    function applyGroupVisibility() {
+      if (!toggleModules.checked) {
+        cy.nodes('[kind = "group"]').addClass("hidden");
+        return;
+      }
+
+      cy.nodes('[kind = "group"]').removeClass("hidden");
+      if (toggleEmptyGroups.checked) {
+        return;
+      }
+
+      cy.nodes('[kind = "group"]').forEach((group) => {
+        if (isAggregateOverview()) {
+          if (group.connectedEdges().filter((edge) => !edge.hasClass("hidden")).length === 0) {
+            group.addClass("hidden");
+          }
+          return;
+        }
+
+        const visibleChildren = group.children().filter((child) => !child.hasClass("hidden"));
+        const usedChildren = visibleChildren.filter((child) => {
+          return child.connectedEdges().filter((edge) => !edge.hasClass("hidden")).length > 0;
+        });
+        if (usedChildren.length === 0) {
+          group.addClass("hidden");
+        }
+      });
+    }
+
+    function pruneUnusedNodes() {
+      if (toggleEmptyGroups.checked || isAggregateOverview()) {
+        return;
+      }
+
+      cy.nodes().forEach((node) => {
+        if (node.data("kind") === "group" || node.hasClass("hidden")) {
+          return;
+        }
+        if (node.connectedEdges().filter((edge) => !edge.hasClass("hidden")).length === 0) {
+          node.addClass("hidden");
+        }
+      });
+    }
+
+    function applyVisibility() {
+      cy.elements().removeClass("hidden");
+      applyModuleOrganization();
+
+      cy.nodes().forEach((node) => {
+        if (node.data("kind") === "config" && !toggleConfig.checked) {
+          node.addClass("hidden");
+        }
+      });
+
+      cy.edges().forEach((edge) => {
+        const isAggregate = edge.data("kind") === "aggregate";
+        if (
+          isAggregate !== isAggregateOverview() ||
+          edge.source().hasClass("hidden") ||
+          edge.target().hasClass("hidden")
+        ) {
+          edge.addClass("hidden");
+        }
+      });
+
+      pruneUnusedNodes();
+      cy.edges().forEach((edge) => {
+        const isAggregate = edge.data("kind") === "aggregate";
+        if (
+          isAggregate !== isAggregateOverview() ||
+          edge.source().hasClass("hidden") ||
+          edge.target().hasClass("hidden")
+        ) {
+          edge.addClass("hidden");
+        }
+        edge.data(
+          "display_label",
+          toggleEdgeLabels.checked && edge.data("kind") === "dependency" ? edge.data("label") : ""
+        );
+      });
+
+      cy.nodes('[kind = "group"]').removeClass("dimmed");
+      applyGroupVisibility();
+
+      const query = search.value.trim().toLowerCase();
+      cy.elements().removeClass("dimmed");
+      if (!query) {
+        return;
+      }
+
+      const hits = cy.nodes().filter((node) => {
+        return !node.hasClass("hidden") && (
+          String(node.data("label") || "").toLowerCase().includes(query) ||
+          String(node.data("module") || "").toLowerCase().includes(query)
+        );
+      });
+
+      cy.elements().addClass("dimmed");
+      hits.removeClass("dimmed");
+      hits.connectedEdges().removeClass("dimmed");
+      hits.connectedEdges().connectedNodes().removeClass("dimmed");
+      cy.nodes('[kind = "group"]').removeClass("dimmed");
+      applyGroupVisibility();
+    }
+
+    function showNeighborhood(node) {
+      activeNodeId = node.id();
+      applyVisibility();
+      cy.elements().removeClass("dimmed highlight-selected highlight-dependency highlight-dependant");
+      cy.elements().addClass("dimmed");
+      cy.nodes('[kind = "group"]').removeClass("dimmed");
+
+      const dependencies = node.predecessors();
+      const dependants = node.successors();
+      const dependencyNodes = dependencies.filter("node");
+      const dependencyEdges = dependencies.filter("edge");
+      const dependantNodes = dependants.filter("node");
+      const dependantEdges = dependants.filter("edge");
+
+      node.removeClass("dimmed");
+      node.addClass("highlight-selected");
+      dependencyNodes.removeClass("dimmed");
+      dependencyNodes.addClass("highlight-dependency");
+      dependencyEdges.removeClass("dimmed");
+      dependantNodes.removeClass("dimmed");
+      dependantNodes.addClass("highlight-dependant");
+      dependantEdges.removeClass("dimmed");
+
+      renderDetails(node, {
+        modeLabel: null,
+        dependencies: node.incomers("node"),
+        dependants: node.outgoers("node"),
+      });
+    }
+
+    function showDependencyPaths(node) {
+      activeNodeId = node.id();
+      applyVisibility();
+      cy.elements().removeClass("dimmed highlight-selected highlight-dependency highlight-dependant");
+      cy.elements().addClass("dimmed");
+      cy.nodes('[kind = "group"]').removeClass("dimmed");
+
+      const dependencies = node.predecessors();
+      const dependencyNodes = dependencies.filter("node");
+      const dependencyEdges = dependencies.filter("edge");
+
+      node.removeClass("dimmed");
+      node.addClass("highlight-selected");
+      dependencyNodes.removeClass("dimmed");
+      dependencyNodes.addClass("highlight-dependency");
+      dependencyEdges.removeClass("dimmed");
+
+      renderDetails(node, {
+        modeLabel: "Dependency paths",
+        dependencies: node.incomers("node"),
+        dependants: cy.collection(),
+      });
+    }
+
+    function resetFocus() {
+      activeNodeId = null;
+      cy.elements().removeClass("dimmed highlight-selected highlight-dependency highlight-dependant");
+      applyVisibility();
+      details.innerHTML = `
+        <h2>No node selected</h2>
+        <p class="details-empty">Left click for the full neighborhood. Right click for dependency paths only.</p>
+      `;
+    }
+
+    function getKindDetails(kind) {
+      if (kind === "consumer") {
+        const label = String(arguments[1] || "");
+        if (label.startsWith("🌐 ")) {
+          return { label: "Route", color: "#ecfccb" };
+        }
+        if (label.startsWith("ƒ ")) {
+          return { label: "Function", color: "#ecfccb" };
+        }
+        return { label: "Function", color: "#ecfccb" };
+      }
+      if (kind === "service") return { label: "Class injectable", color: "#fff7ed" };
+      if (kind === "factory") return { label: "Factory", color: "#eef6ff" };
+      if (kind === "config") return { label: "Configuration", color: "#f6f2ff" };
+      if (kind === "group") return { label: "Module group", color: "#fef3c7" };
+      return { label: kind || "Unknown", color: "#e5e7eb" };
+    }
+
+    function escapeHtml(value) {
+      return String(value)
+        .replace(/&/g, "&amp;")
+        .replace(/</g, "&lt;")
+        .replace(/>/g, "&gt;")
+        .replace(/"/g, "&quot;")
+        .replace(/'/g, "&#39;");
+    }
+
+    function formatLifetime(value) {
+      if (!value) return null;
+      return value.charAt(0).toUpperCase() + value.slice(1);
+    }
+
+    function renderNeighborPills(nodes) {
+      const uniqueNodes = [];
+      const seen = new Set();
+      nodes.forEach((item) => {
+        if (item.isNode && item.isNode() && !seen.has(item.id())) {
+          seen.add(item.id());
+          uniqueNodes.push(item);
+        }
+      });
+
+      if (!uniqueNodes.length) {
+        return '<span class="details-pill empty">None</span>';
+      }
+
+      return uniqueNodes
+        .sort((left, right) => String(left.data("label")).localeCompare(String(right.data("label"))))
+        .map((item) => `
+          <button class="details-pill" type="button" data-node-id="${escapeHtml(item.id())}">
+            <span>${escapeHtml(String(item.data("label")).replace(/\\n/g, " "))}</span>
+          </button>
+        `)
+        .join("");
+    }
+
+    function renderDetails(node, { modeLabel, dependencies, dependants }) {
+      const kindInfo = getKindDetails(node.data("kind"), node.data("label"));
+      const rows = [
+        `<dt>Kind</dt><dd><span class="details-value">` +
+          `<span class="details-kind-box" style="background:${kindInfo.color};"></span>` +
+          `<span>${kindInfo.label}</span></span></dd>`
+      ];
+
+      const lifetime = formatLifetime(node.data("lifetime"));
+      if (lifetime) {
+        rows.push(`<dt>Lifetime</dt><dd>${escapeHtml(lifetime)}</dd>`);
+      }
+      if (node.data("module")) {
+        rows.push(`<dt>Module</dt><dd class="details-meta-code">${escapeHtml(node.data("module"))}</dd>`);
+      }
+      if (node.data("factory_name")) {
+        rows.push(`<dt>Factory</dt><dd class="details-meta-code">${escapeHtml(node.data("factory_name"))}</dd>`);
+      }
+      if (modeLabel) {
+        rows.push(`<dt>Mode</dt><dd>${escapeHtml(modeLabel)}</dd>`);
+      }
+
+      const dependencyPills = renderNeighborPills(dependencies);
+      const dependantPills = renderNeighborPills(dependants);
+
+      details.innerHTML = `
+        <h2>${escapeHtml(String(node.data("label")).replace(/\\n/g, " "))}</h2>
+        <div class="details-section">
+          <div class="details-section-title">Details</div>
+          <dl>${rows.join("")}</dl>
+        </div>
+        <div class="details-section">
+          <div class="details-section-title">Depends on</div>
+          <div class="details-pills">${dependencyPills}</div>
+        </div>
+        <div class="details-section">
+          <div class="details-section-title">Used by</div>
+          <div class="details-pills">${dependantPills}</div>
+        </div>
+        <p class="details-subtitle">Select any related node below to jump across the graph.</p>
+      `;
+    }
+
+    [toggleConfig, toggleEdgeLabels, toggleEmptyGroups].forEach((checkbox) => {
+      checkbox.addEventListener("change", applyVisibility);
+    });
+
+    layoutMode.addEventListener("change", () => {
+      clearStoredPositions();
+      rerunLayout();
+    });
+
+    toggleModules.addEventListener("change", () => {
+      resetFocus();
+      if (!restorePositions()) {
+        rerunLayout();
+      }
+    });
+
+    search.addEventListener("input", applyVisibility);
+    resetViewportButton.addEventListener("click", () => {
+      cy.fit(cy.elements(":visible"), VIEWPORT_PADDING);
+      setControlsOpen(false);
+    });
+    exportPngButton.addEventListener("click", () => {
+      const png = cy.png({ full: true, scale: 2, bg: readCssVar("--bg-canvas") });
+      const link = document.createElement("a");
+      link.href = png;
+      link.download = "wireup-graph.png";
+      link.click();
+      setControlsOpen(false);
+    });
+    themeToggleButton.addEventListener("click", () => {
+      const nextTheme = document.documentElement.getAttribute("data-theme") === "dark" ? "light" : "dark";
+      applyTheme(nextTheme);
+      setControlsOpen(false);
+    });
+    resetLayoutButton.addEventListener("click", () => {
+      clearStoredPositions();
+      rerunLayout();
+      setControlsOpen(false);
+    });
+    controlsToggleButton.addEventListener("click", () => {
+      setControlsOpen(controlsPanel.hidden);
+    });
+
+    cy.on("tap", "node", (event) => {
+      if (event.target.data("kind") !== "group") {
+        showNeighborhood(event.target);
+      }
+    });
+    cy.on("cxttap", "node", (event) => {
+      if (event.target.data("kind") !== "group") {
+        showDependencyPaths(event.target);
+      }
+    });
+    cy.on("tap", (event) => {
+      if (event.target === cy) {
+        resetFocus();
+      }
+    });
+    details.addEventListener("click", (event) => {
+      const button = event.target.closest("[data-node-id]");
+      if (!button) return;
+      const nextNode = cy.getElementById(button.getAttribute("data-node-id"));
+      if (nextNode && nextNode.length) {
+        showNeighborhood(nextNode);
+      }
+    });
+    cy.on("dragfreeon", "node", (event) => {
+      snapNodeToGrid(event.target);
+      savePositions();
+    });
+    cyContainer.addEventListener("contextmenu", (event) => {
+      event.preventDefault();
+    });
+    document.addEventListener("click", (event) => {
+      if (!controlsPanel.hidden && !event.target.closest(".controls-menu")) {
+        setControlsOpen(false);
+      }
+    });
+
+    const storedTheme = window.localStorage.getItem(getThemeStorageKey());
+    if (storedTheme === "light" || storedTheme === "dark") {
+      document.documentElement.setAttribute("data-theme", storedTheme);
+    }
+    const storedLayout = window.localStorage.getItem(getLayoutStorageKey());
+    if (storedLayout && [...layoutMode.options].some((option) => option.value === storedLayout)) {
+      layoutMode.value = storedLayout;
+    }
+    renderLegend();
+    applyCytoscapeTheme();
+    applyVisibility();
+    if (!restorePositions()) {
+      rerunLayout();
+    }
+  </script>
+</body>
+</html>
+"""
+
+
+def _escape_html(value: str) -> str:
+    return value.replace("&", "&amp;").replace("<", "&lt;").replace(">", "&gt;")
+
+
+def render_graph_page(container: BaseContainer, *, title: str, options: GraphEndpointOptions) -> str:
+    graph_data = to_graph_data(
+        container,
+        options=GraphOptions(base_module=options.base_module),
+    )
+    return full_page_renderer(graph_data, title=title)
+
+
+def full_page_renderer(graph_data: GraphData, *, title: str = "Wireup Graph") -> str:
+    payload = _escape_html(json.dumps(asdict(graph_data), separators=(",", ":"), ensure_ascii=False))
+    return _FULL_PAGE_TEMPLATE.replace(_TITLE_PLACEHOLDER, _escape_html(title)).replace(
+        _GRAPH_DATA_PLACEHOLDER, payload
+    )


### PR DESCRIPTION
This addresses #59 but in a different take. I found mermaid to be lacking for any sort of graph produced by this so this is a dynamic renderer utility that returns html with an interacive page for users to decide how to render and a fastapi-specific integration which adds a /_wireup page to render the page if opted-in and also tracks usage of Wireup in fastapi endpoints for better visibility.

Screenshots:

Module view on:
<img width="2141" height="1377" alt="image" src="https://github.com/user-attachments/assets/25891aa3-2338-4ce0-83ad-38eab51c92d2" />

Module view off:
<img width="2141" height="1377" alt="image" src="https://github.com/user-attachments/assets/0ea66229-6f81-4304-ba1d-efcd0a7dc22a" />
