### PR TITLE
Add support for async container to Flask integration.

### DIFF
--- a/test/integration/flask/async_bp.py
+++ b/test/integration/flask/async_bp.py
@@ -1,0 +1,11 @@
+import flask
+from wireup import Injected
+
+from test.shared.shared_services.async_service import AsyncRandomService
+
+async_bp = flask.Blueprint("async_bp", "async_bp")
+
+
+@async_bp.get("/async")
+async def async_route(random: Injected[AsyncRandomService]):
+    return {"lucky_number": await random.get_random()}

--- a/test/integration/flask/test_async_flask_integration.py
+++ b/test/integration/flask/test_async_flask_integration.py
@@ -1,0 +1,37 @@
+import pytest
+import wireup.integration.flask
+from flask import Flask
+from flask.testing import FlaskClient
+
+from test.integration.flask import services as flask_integration_services
+from test.integration.flask.async_bp import async_bp
+from test.shared import shared_services
+
+
+def create_async_app() -> Flask:
+    app = Flask(__name__)
+    app.config["TESTING"] = True
+    app.register_blueprint(async_bp)
+
+    container = wireup.create_async_container(
+        injectables=[shared_services, flask_integration_services],
+        config={**app.config, "custom_params": True},
+    )
+    wireup.integration.flask.setup(container, app)
+
+    return app
+
+
+@pytest.fixture
+def async_app() -> Flask:
+    return create_async_app()
+
+
+@pytest.fixture
+def async_client(async_app: Flask):
+    return async_app.test_client()
+
+
+def test_async_app(async_client: FlaskClient) -> None:
+    res = async_client.get("/async")
+    assert res.status_code == 200

--- a/test/shared/shared_services/async_service.py
+++ b/test/shared/shared_services/async_service.py
@@ -1,0 +1,7 @@
+from wireup import injectable
+
+
+@injectable
+class AsyncRandomService:
+    async def get_random(self) -> int:
+        return 4

--- a/tox.ini
+++ b/tox.ini
@@ -22,9 +22,9 @@ dependency_groups = dev
 [testenv:py313-flask3]
 description = Test flask integration
 deps =
-    Flask>=3.0.0,<4.0.0
+    Flask[async]>=3.0.0,<4.0.0
 commands =
-    pytest test/integration/flask/test_flask_integration.py
+    pytest test/integration/flask/
 
 [testenv:py313-fastapi]
 description = Test fastapi integration  

--- a/wireup/integration/flask.py
+++ b/wireup/integration/flask.py
@@ -1,31 +1,41 @@
-from typing import Optional
+from __future__ import annotations
 
+from functools import singledispatch
+
+from asgiref.sync import async_to_sync
 from flask import Flask, g
 
 from wireup._decorators import inject_from_container
+from wireup.ioc.container.async_container import AsyncContainer, ScopedAsyncContainer
 from wireup.ioc.container.sync_container import ScopedSyncContainer, SyncContainer
 
 
-def _inject_views(container: SyncContainer, app: Flask) -> None:
+def _inject_views(container: SyncContainer | AsyncContainer, app: Flask) -> None:
     inject_scoped = inject_from_container(container, get_request_container)
 
     app.view_functions = {name: inject_scoped(view) for name, view in app.view_functions.items()}
 
 
-def setup(container: SyncContainer, app: Flask) -> None:
+@singledispatch
+def setup(container: SyncContainer | AsyncContainer, app: Flask) -> None:
     """Integrate Wireup with Flask.
 
     Setup performs the following:
     * Injects dependencies into Flask views.
     * Creates a new container scope for each request, with a scoped lifetime matching the request duration.
     """
+    msg = "Unsupported type"
+    raise NotImplementedError(msg)
 
+
+@setup.register(SyncContainer)
+def setup_sync(container: SyncContainer, app: Flask) -> None:
     def _before_request() -> None:
         ctx = container.enter_scope()
         g.wireup_container_ctx = ctx
         g.wireup_container = ctx.__enter__()
 
-    def _teardown_request(exc: Optional[BaseException] = None) -> None:
+    def _teardown_request(exc: BaseException | None = None) -> None:
         if ctx := getattr(g, "wireup_container_ctx", None):
             ctx.__exit__(type(exc) if exc else None, exc, exc.__traceback__ if exc else None)
 
@@ -36,11 +46,29 @@ def setup(container: SyncContainer, app: Flask) -> None:
     app.wireup_container = container  # type: ignore[reportAttributeAccessIssue]
 
 
-def get_app_container(app: Flask) -> SyncContainer:
+@setup.register(AsyncContainer)
+def setup_async(container: AsyncContainer, app: Flask) -> None:
+    def _before_request() -> None:
+        ctx = container.enter_scope()
+        g.wireup_container_ctx = ctx
+        g.wireup_container = async_to_sync(ctx.__aenter__)()
+
+    def _teardown_request(exc: BaseException | None = None) -> None:
+        if ctx := getattr(g, "wireup_container_ctx", None):
+            async_to_sync(ctx.__aexit__)(type(exc) if exc else None, exc, exc.__traceback__ if exc else None)
+
+    app.before_request(_before_request)
+    app.teardown_request(_teardown_request)
+
+    _inject_views(container, app)
+    app.wireup_container = container
+
+
+def get_app_container(app: Flask) -> SyncContainer | AsyncContainer:
     """Return the container associated with the given application."""
     return app.wireup_container  # type: ignore[reportAttributeAccessIssue]
 
 
-def get_request_container() -> ScopedSyncContainer:
+def get_request_container() -> ScopedSyncContainer | ScopedAsyncContainer:
     """Return the container handling the current request."""
     return g.wireup_container

--- a/wireup/integration/flask.py
+++ b/wireup/integration/flask.py
@@ -28,7 +28,7 @@ def setup(container: SyncContainer | AsyncContainer, app: Flask) -> None:
     raise NotImplementedError(msg)
 
 
-@setup.register(SyncContainer)
+@setup.register
 def setup_sync(container: SyncContainer, app: Flask) -> None:
     def _before_request() -> None:
         ctx = container.enter_scope()
@@ -46,7 +46,7 @@ def setup_sync(container: SyncContainer, app: Flask) -> None:
     app.wireup_container = container  # type: ignore[reportAttributeAccessIssue]
 
 
-@setup.register(AsyncContainer)
+@setup.register
 def setup_async(container: AsyncContainer, app: Flask) -> None:
     def _before_request() -> None:
         ctx = container.enter_scope()


### PR DESCRIPTION
If I try the Flask integration with an async container like so:

```python
from flask import Flask
import wireup
import wireup.integration.flask

app = Flask(__name__)
container = wireup.create_async_container(injectables=[], config={})
wireup.integration.flask.setup(container, app)
```

I get a runtime exception:

```
exc = AttributeError("'ScopedAsyncContainer' object has no attribute '__enter__'")

    def _teardown_request(exc: Optional[BaseException] = None) -> None:
        if ctx := getattr(g, "wireup_container_ctx", None):
>           ctx.__exit__(type(exc) if exc else None, exc, exc.__traceback__ if exc else None)
            ^^^^^^^^^^^^
E           AttributeError: 'ScopedAsyncContainer' object has no attribute '__exit__'. Did you mean: '__aexit__'?
```

It looks like the Flask integration doesn't yet work with async containers.