### PR TITLE
Added LRU cache to WireupTask to prevent recompilation

### DIFF
--- a/docs/pages/class/fastapi_integration.md
+++ b/docs/pages/class/fastapi_integration.md
@@ -1,3 +1,8 @@
 ## wireup.integration.fastapi
 
 ::: wireup.integration.fastapi
+
+!!! note
+    For best performance, use regular functions rather than callables or closures 
+    as dependencies. Callables and closures are not hashable and cannot be cached 
+    by the injection system.

--- a/docs/pages/class/fastapi_integration.md
+++ b/docs/pages/class/fastapi_integration.md
@@ -3,6 +3,6 @@
 ::: wireup.integration.fastapi
 
 !!! note
-    For best performance, use regular functions rather than callables or closures 
-    as dependencies. Callables and closures are not hashable and cannot be cached 
-    by the injection system.
+    For best performance with `WireupTask`, prefer regular top-level functions for background task callbacks.
+    Wireup creates cached injection wrappers for top-level functions, but callable objects and nested
+    functions/closures do not benefit from that caching.

--- a/docs/pages/class/starlette_integration.md
+++ b/docs/pages/class/starlette_integration.md
@@ -3,6 +3,6 @@
 ::: wireup.integration.starlette
 
 !!! note
-    For best performance, use regular functions rather than callables or closures
-    as dependencies. Callables and closures are not hashable and cannot be cached
-    by the injection system.
+    For best performance with `WireupTask`, prefer regular top-level functions for background task callbacks.
+    Wireup creates cached injection wrappers for top-level functions, but callable objects and nested
+    functions/closures do not benefit from that caching.

--- a/docs/pages/class/starlette_integration.md
+++ b/docs/pages/class/starlette_integration.md
@@ -1,3 +1,8 @@
 ## wireup.integration.flask
 
 ::: wireup.integration.starlette
+
+!!! note
+    For best performance, use regular functions rather than callables or closures
+    as dependencies. Callables and closures are not hashable and cannot be cached
+    by the injection system.

--- a/test/integration/starlette/test_starlette_integration.py
+++ b/test/integration/starlette/test_starlette_integration.py
@@ -1,3 +1,4 @@
+import types
 from typing import Iterator
 from uuid import uuid4
 
@@ -278,3 +279,66 @@ def test_setup_allows_reusing_container_across_apps() -> None:
 
     wireup.integration.starlette.setup(container, app_one)
     wireup.integration.starlette.setup(container, app_two)
+
+
+def test_wireup_task_caches_regular_functions() -> None:
+    def write_logs_a(greeter: Injected[GreeterService]) -> None:
+        pass
+
+    def write_logs_b(greeter: Injected[GreeterService]) -> None:
+        pass
+
+    container = wireup.create_async_container(injectables=[shared_services, wireup.integration.starlette])
+    task = WireupTask(container)
+    task._get_injected_wrapper.cache_clear()
+
+    task(write_logs_a)
+    task(write_logs_a)  # should hit cache
+    task(write_logs_b)
+
+    info = task._get_injected_wrapper.cache_info()
+    assert info.hits == 1
+    assert info.misses == 2
+    assert info.currsize == 2
+
+
+def test_wireup_task_does_not_cache_closures() -> None:
+    def make_closure():
+        def write_logs(greeter: Injected[GreeterService]) -> None:
+            pass
+
+        return write_logs
+
+    closure_fn = make_closure()
+    assert "<locals>" in closure_fn.__qualname__
+
+    container = wireup.create_async_container(injectables=[shared_services, wireup.integration.starlette])
+    task = WireupTask(container)
+    task._get_injected_wrapper.cache_clear()
+
+    task(closure_fn)
+    task(closure_fn)
+
+    info = task._get_injected_wrapper.cache_info()
+    assert info.hits == 0
+    assert info.misses == 0
+
+
+def test_wireup_task_does_not_cache_callable_instances() -> None:
+    class CallableTask:
+        def __call__(self, greeter: Injected[GreeterService]) -> None:
+            pass
+
+    callable_instance = CallableTask()
+    assert not isinstance(callable_instance, types.FunctionType)
+
+    container = wireup.create_async_container(injectables=[shared_services, wireup.integration.starlette])
+    task = WireupTask(container)
+    task._get_injected_wrapper.cache_clear()
+
+    task(callable_instance)
+    task(callable_instance)
+
+    info = task._get_injected_wrapper.cache_info()
+    assert info.hits == 0
+    assert info.misses == 0

--- a/test/integration/starlette/test_starlette_integration.py
+++ b/test/integration/starlette/test_starlette_integration.py
@@ -280,10 +280,14 @@ def test_setup_allows_reusing_container_across_apps() -> None:
     wireup.integration.starlette.setup(container, app_one)
     wireup.integration.starlette.setup(container, app_two)
 
+
 def write_logs_a(greeter: Injected[GreeterService]) -> None:
-        pass
+    pass
+
+
 def write_logs_b(greeter: Injected[GreeterService]) -> None:
-        pass
+    pass
+
 
 def test_wireup_task_caches_regular_functions() -> None:
     container = wireup.create_async_container(injectables=[shared_services, wireup.integration.starlette])

--- a/test/integration/starlette/test_starlette_integration.py
+++ b/test/integration/starlette/test_starlette_integration.py
@@ -280,14 +280,12 @@ def test_setup_allows_reusing_container_across_apps() -> None:
     wireup.integration.starlette.setup(container, app_one)
     wireup.integration.starlette.setup(container, app_two)
 
+def write_logs_a(greeter: Injected[GreeterService]) -> None:
+        pass
+def write_logs_b(greeter: Injected[GreeterService]) -> None:
+        pass
 
 def test_wireup_task_caches_regular_functions() -> None:
-    def write_logs_a(greeter: Injected[GreeterService]) -> None:
-        pass
-
-    def write_logs_b(greeter: Injected[GreeterService]) -> None:
-        pass
-
     container = wireup.create_async_container(injectables=[shared_services, wireup.integration.starlette])
     task = WireupTask(container)
     task._get_injected_wrapper.cache_clear()

--- a/wireup/integration/starlette.py
+++ b/wireup/integration/starlette.py
@@ -13,6 +13,8 @@ from wireup.errors import WireupError
 from wireup.ioc.container.async_container import AsyncContainer, ScopedAsyncContainer
 from wireup.ioc.types import AnyCallable
 
+from functools import lru_cache
+
 request_container: ContextVar[ScopedAsyncContainer] = ContextVar("wireup_scoped_container")
 
 
@@ -113,13 +115,14 @@ def get_request_container() -> ScopedAsyncContainer:
 
 
 class WireupTask:
-    __slots__ = ("container",)
+    __slots__ = ("container", "_get_injected_wrapper",)
 
     def __init__(self, container: AsyncContainer) -> None:
         self.container = container
+        self._get_injected_wrapper = lru_cache(maxsize=128)(inject_from_container(self.container))
 
     def __call__(self, fn: AnyCallable) -> Any:
-        return inject_from_container(self.container)(fn)
+        return self._get_injected_wrapper(fn)
 
 
 inject = inject_from_container_unchecked(get_request_container, hide_annotated_names=True)

--- a/wireup/integration/starlette.py
+++ b/wireup/integration/starlette.py
@@ -1,7 +1,7 @@
 import contextlib
+import types
 from contextvars import ContextVar
 from functools import lru_cache
-import types
 from typing import Any, AsyncIterator
 
 from starlette.applications import Starlette

--- a/wireup/integration/starlette.py
+++ b/wireup/integration/starlette.py
@@ -1,6 +1,7 @@
 import contextlib
 from contextvars import ContextVar
 from functools import lru_cache
+import types
 from typing import Any, AsyncIterator
 
 from starlette.applications import Starlette
@@ -121,7 +122,10 @@ class WireupTask:
         self._get_injected_wrapper = lru_cache(maxsize=128)(inject_from_container(self.container))
 
     def __call__(self, fn: AnyCallable) -> Any:
-        return self._get_injected_wrapper(fn)
+        should_cache = isinstance(fn, types.FunctionType) and "<locals>" not in fn.__qualname__
+        if should_cache:
+            return self._get_injected_wrapper(fn)
+        return inject_from_container(self.container)(fn)
 
 
 inject = inject_from_container_unchecked(get_request_container, hide_annotated_names=True)

--- a/wireup/integration/starlette.py
+++ b/wireup/integration/starlette.py
@@ -1,5 +1,6 @@
 import contextlib
 from contextvars import ContextVar
+from functools import lru_cache
 from typing import Any, AsyncIterator
 
 from starlette.applications import Starlette
@@ -12,8 +13,6 @@ from wireup._decorators import inject_from_container, inject_from_container_unch
 from wireup.errors import WireupError
 from wireup.ioc.container.async_container import AsyncContainer, ScopedAsyncContainer
 from wireup.ioc.types import AnyCallable
-
-from functools import lru_cache
 
 request_container: ContextVar[ScopedAsyncContainer] = ContextVar("wireup_scoped_container")
 
@@ -115,7 +114,7 @@ def get_request_container() -> ScopedAsyncContainer:
 
 
 class WireupTask:
-    __slots__ = ("container", "_get_injected_wrapper",)
+    __slots__ = ("_get_injected_wrapper", "container")
 
     def __init__(self, container: AsyncContainer) -> None:
         self.container = container


### PR DESCRIPTION
In the original code, every time WireupTask was called, it ran inject_from_container(self.container)(fn) - which is kind of a factory. It builds a tool to inject dependencies. Running that factory and then applying it to the function (fn) is computationally very heavy. If you have a background task running every 5 seconds, you are rebuilding that same injection wrapper every 5 seconds, even though the container and the function haven't changed.