### PR TITLE
docs: add FastAPI integration lifecycle sequence diagrams

### DIFF
--- a/docs/pages/integrations/fastapi/index.md
+++ b/docs/pages/integrations/fastapi/index.md
@@ -86,6 +86,67 @@ Run the server with:
 fastapi dev main.py
 ```
 
+## Lifecycle
+
+Wireup integrates with FastAPI at two levels: once during application startup/shutdown, and once per incoming request.
+
+### App Lifecycle
+
+Container creation, route injection, and teardown.
+
+```mermaid
+sequenceDiagram
+    participant App as Application Code
+    participant Container as Wireup Container
+    participant Integration as wireup.integration.fastapi
+    participant FastAPI
+
+    App->>Container: wireup.create_async_container(injectables=[...])
+    App->>Integration: setup(container, app)
+    Integration->>FastAPI: Store container on app.state
+    Integration->>Integration: Update lifespan context
+    Integration->>FastAPI: Inject existing routes
+
+    Note over FastAPI: App startup
+    FastAPI->>Integration: Lifespan enter
+    Integration->>Integration: Instantiate class-based routes (if any)
+    Integration->>FastAPI: Inject routes (idempotent)
+    Integration-->>FastAPI: Yield to app lifespan
+
+    Note over FastAPI: App running, handling requests...
+
+    Note over FastAPI: App shutdown
+    FastAPI->>Integration: Lifespan exit
+    Integration->>Container: container.close()
+    Container-->>Integration: Resources cleaned up
+```
+
+### Per-Request Lifecycle
+
+Scope creation, dependency resolution, and cleanup for a single HTTP request.
+
+```mermaid
+sequenceDiagram
+    participant Client
+    participant FastAPI
+    participant Wireup as Injection Wrapper
+    participant Container as Scoped Container
+    participant Handler as Route Handler
+
+    Client->>FastAPI: HTTP Request
+    FastAPI->>Wireup: Route matched, call handler
+    Wireup->>Wireup: Extract Request from kwargs
+    Wireup->>Container: Create request scope
+    Container->>Container: Resolve Injected[T] parameters
+    Container-->>Wireup: Resolved dependencies
+    Wireup->>Handler: Call with resolved dependencies
+    Handler-->>Wireup: Response
+    Wireup->>Container: Exit request scope
+    Container->>Container: Clean up request-scoped resources
+    Wireup-->>FastAPI: Return response
+    FastAPI-->>Client: HTTP Response
+```
+
 ## Detailed Guides
 
 - [Inject in Routes](inject_in_routes.md): HTTP/WebSocket handler injection and config value injection in route signatures.


### PR DESCRIPTION
## Summary

Adds two mermaid sequence diagrams to the FastAPI integration docs page, covering the app lifecycle and per-request lifecycle.

Fixes #120

## Why this matters

Issue #120 identified that the FastAPI integration page lacked visual documentation of what happens under the hood. The `setup()` call wires together lifespan management, route injection, and container teardown, but the existing docs only show the Quick Start code. These diagrams trace the actual call flow through `wireup/integration/fastapi.py` so users can see how container creation, route injection, scope handling, and cleanup connect.

## Changes

Added a `## Lifecycle` section to `docs/pages/integrations/fastapi/index.md` between Quick Start and Detailed Guides:

- **App Lifecycle** diagram: `create_async_container` -> `setup()` -> lifespan enter (route injection, class-based handler instantiation) -> app runs -> lifespan exit (`container.close()`)
- **Per-Request Lifecycle** diagram: request arrival -> injection wrapper intercepts -> request scope created -> `Injected[T]` resolved -> handler called -> scope exits -> response returned

Both diagrams render via the existing mermaid fence configured in `mkdocs.yml` (line 143-146).

## Testing

- Verified mermaid is configured as a custom fence in `docs/mkdocs.yml`
- Diagram participants and flow match the actual source in `wireup/integration/fastapi.py`