### PR TITLE
fix: pass type_params to _eval_type on Python 3.13 to suppress DeprecationWarning

### DIFF
--- a/wireup/ioc/util.py
+++ b/wireup/ioc/util.py
@@ -128,7 +128,7 @@ def _eval_type_native(
 
     This function handles version-specific differences in typing._eval_type.
     """
-    if sys.version_info >= (3, 14):
+    if sys.version_info >= (3, 13):
         res = _eval_type(value, globalns, None, type_params=())
 
         return type(None) if res is None else res


### PR DESCRIPTION
## Summary

`_eval_type_native` in `wireup/ioc/util.py` already passes `type_params=()` on Python 3.14+, but the `DeprecationWarning` fires starting in 3.13. This lowers the version check from `(3, 14)` to `(3, 13)` so the parameter is passed on 3.13 too.

One-line change: `util.py` line 131.

## Why

The `type_params` parameter was added to `typing._eval_type` in Python 3.12. Starting in 3.13, omitting it emits a `DeprecationWarning` (will become an error in 3.15). The existing fix for 3.14 should also cover 3.13.

Fixes #124

This contribution was developed with AI assistance (Claude Code).