### PR TITLE
Add mapping on aggregates

### DIFF
--- a/docs/pages/interfaces.md
+++ b/docs/pages/interfaces.md
@@ -212,6 +212,67 @@ class CacheReporter:
 
 `Sequence[T]` includes the default implementation, if present, plus any qualified implementations in registration order.
 
+## Inject Implementations by Qualifier
+
+When you want every implementation keyed by its qualifier, request them at once with `collections.abc.Mapping[Hashable, T]`.
+
+```python
+from collections.abc import Hashable, Mapping
+from dataclasses import dataclass
+from typing import Protocol
+from wireup import create_sync_container, injectable
+
+
+class Cache(Protocol):
+    def source(self) -> str: ...
+
+
+@injectable(as_type=Cache)
+class InMemoryCache:
+    def source(self) -> str:
+        return "memory"
+
+
+@injectable(as_type=Cache, qualifier="redis")
+class RedisCache:
+    def source(self) -> str:
+        return "redis"
+
+
+@injectable
+@dataclass
+class CacheRouter:
+    caches: Mapping[Hashable, Cache]
+
+    def default(self) -> Cache:
+        return self.caches[None]
+```
+
+`Mapping[Hashable, Cache]` includes every implementation, keyed by its qualifier. The unqualified default is keyed under `None`.
+
+!!! note "Mapping Type"
+
+    Only `collections.abc.Mapping[Hashable, T]` is supported. Requesting `typing.Mapping[K, V]` raises
+    `UnknownServiceRequestedError` with a hint pointing at `collections.abc.Mapping[Hashable, T]`.
+
+    If you want to register your own factory for a `Mapping[Hashable, T]` (e.g., with custom keys or transformation
+    logic), wrap it in a `NewType`:
+
+    ```python
+    from collections.abc import Hashable, Mapping
+    from typing import Annotated, NewType
+    from wireup import Inject, injectable
+
+    CacheMap = NewType("CacheMap", Mapping[Hashable, Cache])
+
+
+    @injectable
+    def make_cache_map(
+        default: Cache,
+        redis: Annotated[Cache, Inject(qualifier="redis")],
+    ) -> CacheMap:
+        return CacheMap({None: default, "redis": redis})
+    ```
 
 ## `as_type` with Optional Types
 

--- a/test/unit/test_container_collection_injection.py
+++ b/test/unit/test_container_collection_injection.py
@@ -1,12 +1,12 @@
 from __future__ import annotations
 
 import typing
-from collections.abc import Sequence
+from collections.abc import Hashable, Mapping, Sequence
 from dataclasses import dataclass
-from typing import Optional, Protocol
+from typing import Annotated, NewType, Optional, Protocol
 
 import pytest
-from wireup import Injected, create_sync_container, inject_from_container, injectable
+from wireup import Inject, Injected, create_sync_container, inject_from_container, injectable
 from wireup._annotations import InjectableDeclaration
 from wireup.errors import UnknownServiceRequestedError, WireupError
 from wireup.ioc.registry import ContainerRegistry
@@ -178,3 +178,190 @@ def test_typing_sequence_dependency_raises_helpful_error() -> None:
         match=r"uses typing\.Sequence\[.*Cache.*\], but Wireup collection injection requires collections\.abc\.Sequence\[.*Cache.*\]",  # noqa: E501
     ):
         create_sync_container(injectables=[MemoryCache, RedisCache, Consumer])
+
+
+def test_injects_collection_mapping_for_as_type() -> None:
+    container = create_sync_container(injectables=[MemoryCache, RedisCache])
+
+    @inject_from_container(container)
+    def handler(caches: Injected[Mapping[Hashable, Cache]]) -> dict[Hashable, str]:
+        return {key: cache.source() for key, cache in caches.items()}
+
+    assert handler() == {None: "memory", "redis": "redis"}
+    assert container.get(Mapping[Hashable, Cache]) is container.get(Mapping[Hashable, Cache])
+
+
+def test_injects_collection_mapping_for_single_implementation() -> None:
+    container = create_sync_container(injectables=[MemoryCache])
+    res = container.get(Mapping[Hashable, Cache])
+
+    assert isinstance(res, dict)
+    assert list(res.keys()) == [None]
+    assert res[None].source() == "memory"
+
+
+def test_default_impl_appears_under_none_key() -> None:
+    container = create_sync_container(injectables=[MemoryCache])
+    res = container.get(Mapping[Hashable, Cache])
+
+    assert res[None].source() == "memory"
+
+
+def test_mapping_works_with_only_qualified_impls() -> None:
+    @injectable(as_type=Cache, qualifier="memory")
+    class QualifiedMemoryCache:
+        def source(self) -> str:
+            return "memory"
+
+    container = create_sync_container(injectables=[QualifiedMemoryCache, RedisCache])
+    res = container.get(Mapping[Hashable, Cache])
+
+    assert set(res.keys()) == {"memory", "redis"}
+    assert None not in res
+
+
+def test_mapping_supports_non_string_qualifiers() -> None:
+    @injectable(as_type=Cache, qualifier=0)
+    class ZeroCache:
+        def source(self) -> str:
+            return "zero"
+
+    @injectable(as_type=Cache, qualifier=1)
+    class OneCache:
+        def source(self) -> str:
+            return "one"
+
+    container = create_sync_container(injectables=[ZeroCache, OneCache])
+    res = container.get(Mapping[Hashable, Cache])
+
+    assert res[0].source() == "zero"
+    assert res[1].source() == "one"
+
+
+def test_mapping_lifetime_is_smallest_member_lifetime() -> None:
+    @injectable(as_type=Cache, qualifier="default")
+    class DefaultCache:
+        def source(self) -> str:
+            return "default"
+
+    @injectable(as_type=Cache, qualifier="scoped", lifetime="scoped")
+    class ScopedCache:
+        def source(self) -> str:
+            return "scoped"
+
+    @injectable
+    @dataclass
+    class Consumer:
+        caches: Mapping[Hashable, Cache]
+
+    with pytest.raises(
+        WireupError,
+        match="depends on an injectable with a 'scoped' lifetime which is not supported",
+    ):
+        create_sync_container(injectables=[DefaultCache, ScopedCache, Consumer])
+
+
+def test_can_override_mapping_directly() -> None:
+    container = create_sync_container(injectables=[MemoryCache, RedisCache])
+    override_map = {"override": RedisCache()}
+
+    assert set(container.get(Mapping[Hashable, Cache]).keys()) == {None, "redis"}
+    with container.override.injectable(Mapping[Hashable, Cache], new=override_map):
+        assert container.get(Mapping[Hashable, Cache]) is override_map
+    assert set(container.get(Mapping[Hashable, Cache]).keys()) == {None, "redis"}
+
+
+def test_explicit_mapping_registration_takes_precedence_and_warns() -> None:
+    mapping = {"custom": RedisCache()}
+
+    @injectable
+    def make_custom_mapping() -> Mapping[Hashable, Cache]:
+        return mapping
+
+    with pytest.warns(FutureWarning, match=r"Mapping\[Hashable, T\] is reserved for Wireup collection injection"):
+        container = create_sync_container(injectables=[MemoryCache, make_custom_mapping])
+
+    assert container.get(Mapping[Hashable, Cache]) is mapping
+
+
+def test_injects_collection_mapping_when_registration_key_comes_from_factory_return_type() -> None:
+    @injectable
+    def make_default_cache() -> Cache:
+        return MemoryCache()
+
+    @injectable(qualifier="redis")
+    def make_redis_cache() -> Cache:
+        return RedisCache()
+
+    container = create_sync_container(injectables=[make_default_cache, make_redis_cache])
+    res = container.get(Mapping[Hashable, Cache])
+
+    assert isinstance(res, dict)
+    assert {key: cache.source() for key, cache in res.items()} == {None: "memory", "redis": "redis"}
+
+
+def test_internal_extend_does_not_create_nested_mapping_collections() -> None:
+    registry = ContainerRegistry(impls=[InjectableDeclaration(obj=MemoryCache, lifetime="singleton")])
+
+    @injectable
+    class ExtraService:
+        pass
+
+    registry.extend(impls=[InjectableDeclaration(obj=ExtraService, lifetime="singleton")])
+
+    assert Mapping[Hashable, Mapping[Hashable, MemoryCache]] not in registry.impls
+
+
+def test_mixed_real_and_optional_compat_registrations_only_include_real_members_in_mapping() -> None:
+    @injectable
+    def make_optional_default_cache() -> Cache | None:
+        return None
+
+    @injectable(qualifier="redis")
+    def make_redis_cache() -> Cache:
+        return RedisCache()
+
+    container = create_sync_container(injectables=[make_optional_default_cache, make_redis_cache])
+
+    assert container.get(Mapping[Hashable, Cache]) == {"redis": container.get(Cache, qualifier="redis")}
+
+
+def test_typing_mapping_is_not_registered() -> None:
+    container = create_sync_container(injectables=[MemoryCache, RedisCache])
+
+    with pytest.raises(
+        UnknownServiceRequestedError,
+        match=r"Wireup collection injection uses collections\.abc\.Mapping\[.*Cache.*\], not typing\.Mapping\[.*Cache.*\]",  # noqa: E501
+    ):
+        container.get(typing.Mapping[str, Cache])
+
+
+def test_typing_mapping_dependency_raises_helpful_error() -> None:
+    @injectable
+    @dataclass
+    class Consumer:
+        caches: typing.Mapping[str, Cache]
+
+    with pytest.raises(
+        WireupError,
+        match=r"uses typing\.Mapping\[.*Cache.*\], but Wireup collection injection requires collections\.abc\.Mapping\[.*Cache.*\]",  # noqa: E501
+    ):
+        create_sync_container(injectables=[MemoryCache, RedisCache, Consumer])
+
+
+CacheMap = NewType("CacheMap", Mapping[Hashable, Cache])
+
+
+def test_newtype_over_mapping_registers_as_distinct_collection() -> None:
+    @injectable
+    def make_cache_map(
+        default: Cache,
+        redis: Annotated[Cache, Inject(qualifier="redis")],
+    ) -> CacheMap:
+        return CacheMap({None: default, "redis": redis})
+
+    container = create_sync_container(injectables=[MemoryCache, RedisCache, make_cache_map])
+    res = container.get(CacheMap)
+
+    assert isinstance(res, dict)
+    assert {key: cache.source() for key, cache in res.items()} == {None: "memory", "redis": "redis"}

--- a/test/unit/test_container_creation.py
+++ b/test/unit/test_container_creation.py
@@ -80,6 +80,26 @@ def test_checks_typing_sequence_dependency_uses_helpful_error() -> None:
         wireup.create_sync_container(injectables=[FooImpl, Bar])
 
 
+def test_checks_typing_mapping_dependency_uses_helpful_error() -> None:
+    class Foo(Protocol): ...
+
+    @wireup.injectable(as_type=Foo)
+    class FooImpl:
+        pass
+
+    @wireup.injectable
+    @dataclass
+    class Bar:
+        foo: typing.Mapping[str, Foo]
+
+    with pytest.raises(
+        WireupError,
+        match=r"Parameter 'foo' of Type test\.unit\.test_container_creation\.Bar uses typing\.Mapping\[.*Foo.*\], "
+        r"but Wireup collection injection requires collections\.abc\.Mapping\[.*Foo.*\]\.",
+    ):
+        wireup.create_sync_container(injectables=[FooImpl, Bar])
+
+
 def test_lifetimes_match() -> None:
     @wireup.injectable(lifetime="scoped")
     class ScopedService: ...

--- a/wireup/errors.py
+++ b/wireup/errors.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
 import sys
+from collections.abc import Hashable
+from collections.abc import Mapping as AbcMapping
 from collections.abc import Sequence as AbcSequence
 from typing import TYPE_CHECKING, Any
 
@@ -22,6 +24,20 @@ def try_get_wireup_sequence_replacement(type_hint: Any) -> Any | None:
 
     args = get_args(type_hint)
     return AbcSequence[args] if args else AbcSequence  # type:ignore[valid-type]
+
+
+def try_get_wireup_mapping_replacement(type_hint: Any) -> Any | None:
+    """Return collection type replacement for typing.Mapping[K, V] if applicable."""
+    if getattr(type_hint, "__module__", None) != "typing":
+        return None
+
+    if get_origin(type_hint) is not AbcMapping:
+        return None
+
+    args = get_args(type_hint)
+    if not args:
+        return AbcMapping
+    return AbcMapping[Hashable, args[1]]  # type:ignore[valid-type]
 
 
 class WireupError(Exception):
@@ -98,6 +114,13 @@ class UnknownServiceRequestedError(WireupError):
 
     def __init__(self, klass: Any, qualifier: Qualifier | None = None) -> None:
         if suggested_replacement_type := try_get_wireup_sequence_replacement(klass):
+            super().__init__(
+                f"Cannot create unknown injectable {format_name(klass, qualifier)}. "
+                f"Wireup collection injection uses {suggested_replacement_type!r}, not {klass!r}."
+            )
+            return
+
+        if suggested_replacement_type := try_get_wireup_mapping_replacement(klass):
             super().__init__(
                 f"Cannot create unknown injectable {format_name(klass, qualifier)}. "
                 f"Wireup collection injection uses {suggested_replacement_type!r}, not {klass!r}."

--- a/wireup/ioc/registry.py
+++ b/wireup/ioc/registry.py
@@ -4,7 +4,7 @@ import inspect
 import typing
 import warnings
 from collections import defaultdict
-from collections.abc import Sequence
+from collections.abc import Hashable, Mapping, Sequence
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, Callable, TypeVar, Union
 
@@ -137,6 +137,7 @@ class ContainerRegistry:
             )
 
         self._register_sequence_collections()
+        self._register_mapping_collections()
         validate_registry(self)
         self._update_factories_async_flag()
         if self.on_change:
@@ -200,6 +201,24 @@ class ContainerRegistry:
         _factory.__signature__ = inspect.Signature(parameters=signature_parameters)  # type: ignore[attr-defined]
         return _factory
 
+    def _create_mapping_collection_factory(self, klass: Any, qualifiers: list[Qualifier | None]) -> Callable[..., Any]:
+        def _factory(**kwargs: Any) -> Any:
+            return dict(zip(qualifiers, kwargs.values()))
+
+        signature_parameters = []
+        for idx, qualifier in enumerate(qualifiers):
+            annotation = klass if qualifier is None else Annotated[klass, InjectableQualifier(qualifier)]
+            signature_parameters.append(
+                inspect.Parameter(
+                    f"_wireup_item{idx}",
+                    kind=inspect.Parameter.POSITIONAL_OR_KEYWORD,
+                    annotation=annotation,
+                )
+            )
+
+        _factory.__signature__ = inspect.Signature(parameters=signature_parameters)  # type: ignore[attr-defined]
+        return _factory
+
     def _has_user_defined_sequence_key(self, collection_key: Any) -> bool:
         existing_factory = self.factories.get(get_container_object_id(collection_key, None))
         if existing_factory and not existing_factory.is_synthetic:
@@ -207,6 +226,21 @@ class ContainerRegistry:
                 f"Wireup did not register collection injection for {collection_key!r} "
                 "because the container already has an explicit registration for that key. "
                 "Sequence[T] is reserved for Wireup collection injection. "
+                "Migrate it to a NewType or another distinct collection type.",
+                FutureWarning,
+                stacklevel=4,
+            )
+            return True
+
+        return False
+
+    def _has_user_defined_mapping_key(self, collection_key: Any) -> bool:
+        existing_factory = self.factories.get(get_container_object_id(collection_key, None))
+        if existing_factory and not existing_factory.is_synthetic:
+            warnings.warn(
+                f"Wireup did not register collection injection for {collection_key!r} "
+                "because the container already has an explicit registration for that key. "
+                "Mapping[Hashable, T] is reserved for Wireup collection injection. "
                 "Migrate it to a NewType or another distinct collection type.",
                 FutureWarning,
                 stacklevel=4,
@@ -240,6 +274,36 @@ class ContainerRegistry:
             self._register(
                 klass=collection_key,
                 factory_fn=self._create_sequence_collection_factory(klass, real_qualifiers),
+                lifetime=self._get_collection_lifetime([self.get_lifetime(klass, qual) for qual in real_qualifiers]),
+                auto_discover_interfaces=False,
+                is_synthetic_factory=True,
+            )
+
+    def _register_mapping_collections(self) -> None:
+        for klass, qualifiers in dict(self.impls).items():
+            # Only real registration keys should contribute to collection members.
+            # Synthetic aliases like raw optional-compat or Mapping[Hashable, T] keys must not participate here.
+            real_qualifiers = [
+                qualifier
+                for qualifier in qualifiers
+                if not self.factories[get_container_object_id(klass, qualifier)].is_synthetic
+            ]
+
+            if not real_qualifiers:
+                continue
+
+            collection_key = Mapping[Hashable, klass]  # type:ignore[valid-type]
+
+            if self._has_user_defined_mapping_key(collection_key):
+                continue
+
+            existing_factory = self.factories.get(get_container_object_id(collection_key, None))
+            if existing_factory and existing_factory.is_synthetic:
+                continue
+
+            self._register(
+                klass=collection_key,
+                factory_fn=self._create_mapping_collection_factory(klass, real_qualifiers),
                 lifetime=self._get_collection_lifetime([self.get_lifetime(klass, qual) for qual in real_qualifiers]),
                 auto_discover_interfaces=False,
                 is_synthetic_factory=True,

--- a/wireup/ioc/registry_validation.py
+++ b/wireup/ioc/registry_validation.py
@@ -2,7 +2,12 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any
 
-from wireup.errors import UnknownParameterError, WireupError, try_get_wireup_sequence_replacement
+from wireup.errors import (
+    UnknownParameterError,
+    WireupError,
+    try_get_wireup_mapping_replacement,
+    try_get_wireup_sequence_replacement,
+)
 from wireup.ioc.type_analysis import analyze_type
 from wireup.ioc.types import AnnotatedParameter, ConfigInjectionRequest, get_container_object_id
 from wireup.util import format_name, stringify_type
@@ -103,6 +108,13 @@ def assert_dependency_exists(
             raise WireupError(msg) from e
     elif not is_type_with_qualifier_known(parameter.klass, qualifier=parameter.qualifier_value):
         if suggested_replacement_type := try_get_wireup_sequence_replacement(parameter.klass):
+            msg = (
+                f"Parameter '{name}' of {stringify_type(target)} uses {parameter.klass!r}, "
+                f"but Wireup collection injection requires {suggested_replacement_type!r}."
+            )
+            raise WireupError(msg)
+
+        if suggested_replacement_type := try_get_wireup_mapping_replacement(parameter.klass):
             msg = (
                 f"Parameter '{name}' of {stringify_type(target)} uses {parameter.klass!r}, "
                 f"but Wireup collection injection requires {suggested_replacement_type!r}."


### PR DESCRIPTION
This PR builds on top of `Sequence` support from branch `add-aggregates`, adding mapping support to wireup.

It reuses the exact same architecture as `add-aggregates`.

## This PR adds:
  - `Injected[Mapping[Hashable, T]]` (`collections.abc.Mapping`) as a way to receive every qualified implementation of an interface in a single dict, keyed by qualifier. The unqualified default implementation is included under the `None` key.
  - Targeted hint appended to `UnknownServiceRequestedError` when `typing.Mapping[K, V]` is requested.
  - Unit tests.
  - Documentation.

## This PR does not add:
- Benchmarks
- FastAPI integration test
- Starlette integration test