### PR TITLE
Preserve qualifier on optional factory compat alias

### DIFF
--- a/test/unit/test_inject_from_container_optional_types.py
+++ b/test/unit/test_inject_from_container_optional_types.py
@@ -71,6 +71,30 @@ def test_getting_optional_service_via_plain_type_emits_deprecation_warning() -> 
     assert inst is container.get(Foo | None)
 
 
+def test_optional_factory_with_qualifier() -> None:
+    # https://github.com/maldoinc/wireup/issues/138
+    # A factory returning Optional[T] with a qualifier must preserve the qualifier
+    # on the backwards-compatibility alias factory created for the raw type T.
+    @wireup.injectable
+    class AuthContext:
+        pass
+
+    @wireup.injectable
+    def require_authentication() -> AuthContext:
+        return AuthContext()
+
+    @wireup.injectable(qualifier="optional")
+    def maybe_get_authentication() -> AuthContext | None:
+        return None
+
+    container = wireup.create_sync_container(
+        injectables=[require_authentication, maybe_get_authentication],
+    )
+
+    assert isinstance(container.get(AuthContext), AuthContext)
+    assert container.get(AuthContext | None, qualifier="optional") is None
+
+
 def test_registering_optional_and_plain_type_raises_duplicate() -> None:
     @wireup.injectable
     class Foo:

--- a/wireup/ioc/registry.py
+++ b/wireup/ioc/registry.py
@@ -393,10 +393,10 @@ class ContainerRegistry:
 
                 return raw_type_instance
 
-            # The alias factory depends on the normalized Optional[T] instance. When the
-            # original factory was registered with a qualifier, carry it over so the
-            # dependency resolves to the qualified factory instead of an unqualified one.
-            raw_type_annotation = klass if qualifier is None else Annotated[klass, InjectableQualifier(qualifier)]
+            # The alias factory depends on the normalized Optional[T] instance, carrying
+            # over the original factory's qualifier so it resolves to the same factory.
+            # A None qualifier behaves like the plain type, so this can be unconditional.
+            raw_type_annotation: Any = Annotated[klass, InjectableQualifier(qualifier)]
 
             compat_fn.__signature__ = inspect.Signature(  # type: ignore[attr-defined]
                 parameters=[

--- a/wireup/ioc/registry.py
+++ b/wireup/ioc/registry.py
@@ -393,12 +393,17 @@ class ContainerRegistry:
 
                 return raw_type_instance
 
+            # The alias factory depends on the normalized Optional[T] instance. When the
+            # original factory was registered with a qualifier, carry it over so the
+            # dependency resolves to the qualified factory instead of an unqualified one.
+            raw_type_annotation = klass if qualifier is None else Annotated[klass, InjectableQualifier(qualifier)]
+
             compat_fn.__signature__ = inspect.Signature(  # type: ignore[attr-defined]
                 parameters=[
                     inspect.Parameter(
                         "raw_type_instance",
                         kind=inspect.Parameter.POSITIONAL_OR_KEYWORD,
-                        annotation=klass,
+                        annotation=raw_type_annotation,
                     )
                 ],
             )

--- a/wireup/ioc/registry.py
+++ b/wireup/ioc/registry.py
@@ -393,17 +393,12 @@ class ContainerRegistry:
 
                 return raw_type_instance
 
-            # The alias factory depends on the normalized Optional[T] instance, carrying
-            # over the original factory's qualifier so it resolves to the same factory.
-            # A None qualifier behaves like the plain type, so this can be unconditional.
-            raw_type_annotation: Any = Annotated[klass, InjectableQualifier(qualifier)]
-
             compat_fn.__signature__ = inspect.Signature(  # type: ignore[attr-defined]
                 parameters=[
                     inspect.Parameter(
                         "raw_type_instance",
                         kind=inspect.Parameter.POSITIONAL_OR_KEYWORD,
-                        annotation=raw_type_annotation,
+                        annotation=Annotated[klass, InjectableQualifier(qualifier)],
                     )
                 ],
             )


### PR DESCRIPTION
## Summary
  
  Fixes #138 — factories returning `Optional[T]` with a qualifier failed at container creation with a spurious self-dependency error:

  WireupError: Parameter 'raw_type_instance' of <class 'AuthContext'>
  has an unknown dependency on <class 'AuthContext'>.

  ## Root cause

  When a factory returns `Optional[T]`, Wireup registers a backwards-compatibility alias factory (`compat_fn`) so that `container.get(T)` still resolves to the
  `Optional[T]` instance. That alias's synthetic `raw_type_instance` parameter was annotated with the plain normalized type (`Optional[T]`) **without** carrying the
  qualifier.
  
  As a result, when the original factory was registered with a qualifier, the alias declared a dependency on `(Optional[T], qualifier=None)`, while the real factory
  was registered under `(Optional[T], qualifier)`. The unqualified lookup missed during registry validation, surfacing as an apparent self-dependency on `T`.

  ## Fix

  Preserve the qualifier on the compat alias's parameter annotation, matching the idiom already used for collection factories in the same file:

  ```python
  raw_type_annotation = klass if qualifier is None else Annotated[klass, InjectableQualifier(qualifier)]
```

  When a qualifier is present, the alias now depends on the correctly qualified Optional[T] factory.

  ## Tests

  Added test_optional_factory_with_qualifier, which registers an Optional[T] factory with a qualifier alongside a plain T factory and asserts both resolve. Verified it fails without the fix and passes with it.
