### PR TITLE
Removed compatibility factory for types when Optional[T] factory is defined

### DIFF
--- a/test/unit/test_inject_from_container_optional_types.py
+++ b/test/unit/test_inject_from_container_optional_types.py
@@ -1,10 +1,9 @@
+import warnings
 from dataclasses import dataclass
-from typing import Annotated, Optional, Union
+from typing import Annotated, Optional
 
-import pytest
 import wireup
 from wireup._annotations import Inject, Injected
-from wireup.errors import DuplicateServiceRegistrationError
 
 
 class MaybeThing: ...
@@ -50,37 +49,75 @@ def test_inject_from_container_handles_optionals() -> None:
     main()
 
 
-def test_getting_optional_service_via_plain_type_emits_deprecation_warning() -> None:
-    @wireup.injectable
+def test_getting_optional_service_via_plain_type_resolves_silently() -> None:
     class Foo:
         pass
 
-    @wireup.injectable
+    def make_foo() -> Foo | None:
+        return Foo()
+
+    container = wireup.create_sync_container(injectables=[wireup.injectable(make_foo)])
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
+        inst = container.get(Foo)
+
+    assert isinstance(inst, Foo)
+    assert inst is container.get(optional_hint(Foo))
+    assert inst is container.get(Foo | None)
+
+
+async def test_getting_optional_service_via_plain_type_resolves_silently_async() -> None:
+    class Foo:
+        pass
+
+    def make_foo() -> Foo | None:
+        return Foo()
+
+    container = wireup.create_async_container(injectables=[wireup.injectable(make_foo)])
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
+        inst = await container.get(Foo)
+
+    assert isinstance(inst, Foo)
+    assert inst is await container.get(Foo | None)
+
+
+def test_getting_qualified_optional_service_via_plain_type_keeps_qualifier() -> None:
+    class Foo:
+        pass
+
+    @wireup.injectable(qualifier="primary")
     def make_foo() -> Foo | None:
         return Foo()
 
     container = wireup.create_sync_container(injectables=[make_foo])
 
-    with pytest.warns(DeprecationWarning) as record:
-        inst = container.get(Foo)
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
+        inst = container.get(Foo, qualifier="primary")
 
-    assert len(record) == 1
-    assert "registered as optional" in str(record[0].message)
-
-    assert inst is container.get(optional_hint(Foo))
-    assert inst is container.get(Foo | None)
+    assert isinstance(inst, Foo)
+    assert inst is container.get(Foo | None, qualifier="primary")
 
 
-def test_registering_optional_and_plain_type_raises_duplicate() -> None:
-    @wireup.injectable
+def test_registering_optional_and_plain_type_are_distinct() -> None:
     class Foo:
         pass
 
-    @wireup.injectable
     def make_optional() -> Foo | None:
         return None
 
-    # Registering both an Optional[T] factory and a T factory together raises since
-    # wireup will add a backwards-compatible factory for T when registering it as optional.
-    with pytest.raises(DuplicateServiceRegistrationError):
-        wireup.create_sync_container(injectables=[make_optional, Foo])
+    def make_plain() -> Foo:
+        return Foo()
+
+    # The Optional[T] factory and a plain T factory are distinct registration keys:
+    # T | None and T no longer collide, so retrieving each returns its own instance
+    # and container.get(T) resolves the plain factory directly (not the optional fallback).
+    container = wireup.create_sync_container(
+        injectables=[wireup.injectable(make_optional), wireup.injectable(make_plain)]
+    )
+
+    assert container.get(Foo | None) is None
+    assert isinstance(container.get(Foo), Foo)

--- a/wireup/ioc/container/async_container.py
+++ b/wireup/ioc/container/async_container.py
@@ -42,6 +42,9 @@ class BareAsyncContainer(BaseContainer):
 
             return await res if compiled_factory.is_async else res  # type:ignore[no-any-return]
 
+        if (optional_klass := self._optional_compat_klass(klass, qualifier)) is not None:
+            return await self.get(optional_klass, qualifier)
+
         raise UnknownServiceRequestedError(klass, qualifier)
 
     async def close(self) -> None:

--- a/wireup/ioc/container/base_container.py
+++ b/wireup/ioc/container/base_container.py
@@ -87,6 +87,22 @@ class BaseContainer:
         """Override registered container injectables with new values."""
         return self._override_mgr
 
+    def _optional_compat_klass(self, klass: Callable[..., T] | None, qualifier: Qualifier | None) -> Any:
+        """Backwards-compat fallback for ``container.get``.
+
+        A factory registered as ``Optional[T]`` is also retrievable via ``container.get(T)``.
+        Returns ``T | None`` when that registration exists (so the caller can resolve against it),
+        otherwise ``None``. Only applies to ``container.get``; injected dependencies resolve by
+        their actual annotated type.
+        """
+        try:
+            optional_klass = klass | None  # type: ignore[operator]
+        except TypeError:
+            return None
+
+        obj_id = optional_klass if qualifier is None else (optional_klass, qualifier)
+        return optional_klass if obj_id in self._factories else None
+
     @overload
     def _synchronous_get(self, klass: type[T], qualifier: Qualifier | None = None) -> T: ...
     @overload
@@ -125,6 +141,9 @@ class BaseContainer:
                 raise WireupError(msg)
 
             return compiled_factory.factory(self)  # type:ignore[no-any-return]
+
+        if (optional_klass := self._optional_compat_klass(klass, qualifier)) is not None:
+            return self._synchronous_get(optional_klass, qualifier)  # type: ignore[no-any-return]
 
         raise UnknownServiceRequestedError(klass, qualifier)
 

--- a/wireup/ioc/registry.py
+++ b/wireup/ioc/registry.py
@@ -32,7 +32,6 @@ from wireup.ioc.types import (
     get_container_object_id,
 )
 from wireup.ioc.util import ensure_is_type, get_callable_type, get_globals
-from wireup.util import stringify_type
 
 if TYPE_CHECKING:
     from wireup._annotations import AbstractDeclaration, InjectableDeclaration
@@ -248,7 +247,7 @@ class ContainerRegistry:
     def _register_sequence_collections(self) -> None:
         for klass, qualifiers in dict(self.impls).items():
             # Only real registration keys should contribute to collection members.
-            # Synthetic aliases like raw optional-compat or Sequence[T] keys must not participate here.
+            # Synthetic keys such as Sequence[T] must not participate here.
             real_qualifiers = [
                 qualifier
                 for qualifier in qualifiers
@@ -278,7 +277,7 @@ class ContainerRegistry:
     def _register_mapping_collections(self) -> None:
         for klass, qualifiers in dict(self.impls).items():
             # Only real registration keys should contribute to collection members.
-            # Synthetic aliases like raw optional-compat or Mapping[Hashable, T] keys must not participate here.
+            # Synthetic keys such as Mapping[Hashable, T] must not participate here.
             real_qualifiers = [
                 qualifier
                 for qualifier in qualifiers
@@ -375,42 +374,6 @@ class ContainerRegistry:
             is_synthetic=is_synthetic_factory,
         )
         self.impls[klass].append(qualifier)
-
-        if type_analysis.is_optional:
-            # Backwards compatibility: In earlier versions when a factory returned T | None
-            # you could do container.get(T). Alias that type to the normalized T | None factory.
-            # Create a fake factory that warns and returns the original instance.
-            # https://github.com/maldoinc/wireup/commit/00590dc741035a4c7042c5b6fc434ed08e27f5c0
-            def compat_fn(raw_type_instance: Any) -> Any:
-                type_name = type_analysis.raw_type.__name__
-                deprecated_msg = (
-                    f"Deprecated: {stringify_type(type_analysis.raw_type)} was registered as optional "
-                    f"and retrieving it via container.get({type_name}) is deprecated. "
-                    f"Please use container.get({type_name} | None) or container.get(Optional[{type_name}]) instead."
-                )
-
-                warnings.warn(deprecated_msg, DeprecationWarning, stacklevel=4)
-
-                return raw_type_instance
-
-            compat_fn.__signature__ = inspect.Signature(  # type: ignore[attr-defined]
-                parameters=[
-                    inspect.Parameter(
-                        "raw_type_instance",
-                        kind=inspect.Parameter.POSITIONAL_OR_KEYWORD,
-                        annotation=klass,
-                    )
-                ],
-            )
-
-            self._register(
-                type_analysis.raw_type,
-                factory_fn=compat_fn,
-                lifetime=lifetime,
-                qualifier=qualifier,
-                auto_discover_interfaces=True,
-                is_synthetic_factory=True,
-            )
 
     def _register_abstract(self, klass: type) -> None:
         self.interfaces[klass] = {}


### PR DESCRIPTION
## Summary

  Fixes #138 — factories returning `Optional[T]` registered with a qualifier failed at container creation with a spurious self-dependency error:

  WireupError: Parameter 'raw_type_instance' of <class 'AuthContext'>
  has an unknown dependency on <class 'AuthContext'>.

## Root cause

  To keep `container.get(T)` working when a factory returned `Optional[T]`, Wireup registered an **alias factory** (`compat_fn`) under the raw type `T`. That alias
  depended on the real `Optional[T]` factory — but it built that dependency from the type alone, **dropping the qualifier**.

  So for a qualified factory, the alias looked up `(Optional[T], qualifier=None)` while the real factory was registered under `(Optional[T], qualifier)`. The lookup
  missed, and registry validation reported it as a spurious self-dependency on `T`.

  The alias was also too broad: living under the raw type `T`, it leaked into **injected** resolution as well as `container.get` — but this compatibility should apply
  to `container.get` only.

  ## Fix

  Remove the compatibility alias factory entirely. `Optional[T]` now registers a single factory under its normalized `T | None`   key (qualifier preserved, like any other registration), so the qualifier can never be dropped.

The `container.get(T)` convenience is handled instead as a **fallback on unknown types**, scoped to `get` alone:

  ```python
  # base_container.py — only reached when the requested type isn't registered directly
  if (optional_klass := self._optional_compat_klass(klass, qualifier)) is not None:
      return self._synchronous_get(optional_klass, qualifier)

  _optional_compat_klass returns T | None (carrying the original qualifier) when that registration exists, else None. Injected dependencies never hit this path — they
  resolve by their actual annotated type, which narrows the compatibility surface to container.get as intended.
```

 ## Behavior changes

  - Injected parameters annotated as a bare T (where only Optional[T] was registered) no longer resolve — use T | None. This is the intended narrowing.
  - Optional[T] and a plain T factory are now distinct registration keys and can coexist (previously raised DuplicateServiceRegistrationError, purely as a side effect
  of the alias).
  - container.get(T) for an Optional[T] registration resolves silently (no deprecation warning).

 ## Tests

  - test_getting_qualified_optional_service_via_plain_type_keeps_qualifier — the #138 regression: registers an Optional[T] factory with a qualifier and asserts
  container.get(T, qualifier=...) resolves the correctly qualified instance. Verified it fails without the fix and passes with it.
  - test_getting_optional_service_via_plain_type_resolves_silently (+ async variant) — container.get(T) resolves T | None without emitting any warning.
  - test_registering_optional_and_plain_type_are_distinct — Optional[T] and plain T coexist and each resolves independently.

  All unit tests, mypy --strict, and ruff pass.