### PR TITLE
Fix scoped resource leak on cancellation in exit-stack cleanup

### DIFF
--- a/test/unit/test_exit_stack.py
+++ b/test/unit/test_exit_stack.py
@@ -1,9 +1,18 @@
+import asyncio
 import re
 from collections.abc import AsyncGenerator, Generator
 
 import pytest
 from wireup.errors import WireupError
-from wireup.ioc._exit_stack import clean_exit_stack
+from wireup.ioc._exit_stack import async_clean_exit_stack, clean_exit_stack
+
+
+class _Cancelled(BaseException):
+    """Stand-in for a BaseException (not Exception) re-raised during teardown.
+
+    Mirrors asyncio.CancelledError / KeyboardInterrupt / SystemExit without
+    tripping pytest's session-level handling of the latter two.
+    """
 
 
 def test_clean_exit_stack_with_sync_generators() -> None:
@@ -46,3 +55,66 @@ async def test_clean_exit_stack_with_async_generators_raises() -> None:
         ),
     ):
         clean_exit_stack([(g1, True)])
+
+
+def test_clean_exit_stack_continues_teardown_when_unwinding_base_exception() -> None:
+    # KeyboardInterrupt / SystemExit are BaseException, not Exception. When one is
+    # being unwound, every generator must still be torn down and the stack cleared.
+    teardowns: list[str] = []
+
+    def make(name: str) -> Generator[None, None, None]:
+        try:
+            yield
+        finally:
+            teardowns.append(name)
+
+    g1 = make("first")
+    next(g1)
+    g2 = make("second")
+    next(g2)
+
+    exit_stack = [(g1, False), (g2, False)]
+    clean_exit_stack(exit_stack, exc_val=_Cancelled())
+
+    assert teardowns == ["second", "first"]
+    assert exit_stack == []
+
+
+async def test_async_clean_exit_stack_continues_teardown_on_cancellation() -> None:
+    # Regression: when an `async with container.enter_scope()` block is cancelled
+    # (asyncio.wait_for timeout, task.cancel()), the CancelledError is re-raised by
+    # each generator's teardown. Cleanup must not abort early and leak the rest.
+    teardowns: list[str] = []
+
+    async def make(name: str) -> AsyncGenerator[None, None]:
+        try:
+            yield
+        finally:
+            teardowns.append(name)
+
+    g1 = make("first")
+    await g1.__anext__()
+    g2 = make("second")
+    await g2.__anext__()
+
+    exit_stack = [(g1, True), (g2, True)]
+    await async_clean_exit_stack(exit_stack, exc_val=asyncio.CancelledError())
+
+    assert teardowns == ["second", "first"]
+    assert exit_stack == []
+
+
+async def test_async_clean_exit_stack_propagates_new_base_exception_from_teardown() -> None:
+    # A brand-new BaseException raised during teardown (not the one being unwound)
+    # must still propagate rather than be silently swallowed.
+    async def gen() -> AsyncGenerator[None, None]:
+        try:
+            yield
+        finally:
+            raise KeyboardInterrupt
+
+    g = gen()
+    await g.__anext__()
+
+    with pytest.raises(KeyboardInterrupt):
+        await async_clean_exit_stack([(g, True)])

--- a/wireup/ioc/_exit_stack.py
+++ b/wireup/ioc/_exit_stack.py
@@ -33,12 +33,20 @@ def clean_exit_stack(
         except Exception as e:  # noqa: BLE001
             if e is not exc_val:
                 errors.append(e)
+        except BaseException as e:
+            # CancelledError / KeyboardInterrupt / SystemExit are BaseException, not
+            # Exception. When the exception being unwound (exc_val) re-emerges from a
+            # generator's teardown, keep closing the remaining generators instead of
+            # letting it abort cleanup, which would skip exit_stack.clear() and leak
+            # every earlier-registered resource. A genuinely new one is propagated.
+            if e is not exc_val:
+                raise
 
     exit_stack.clear()
     maybe_raise_exc(exc_val=exc_val, exc_tb=exc_tb, container_close_errors=errors)
 
 
-async def async_clean_exit_stack(
+async def async_clean_exit_stack(  # noqa: C901
     exit_stack: ExitStack,
     exc_val: BaseException | None = None,
     exc_tb: TracebackType | None = None,
@@ -64,6 +72,14 @@ async def async_clean_exit_stack(
         except Exception as e:  # noqa: BLE001
             if e is not exc_val:
                 errors.append(e)
+        except BaseException as e:
+            # CancelledError / KeyboardInterrupt / SystemExit are BaseException, not
+            # Exception. When the exception being unwound (exc_val) re-emerges from a
+            # generator's teardown, keep closing the remaining generators instead of
+            # letting it abort cleanup, which would skip exit_stack.clear() and leak
+            # every earlier-registered resource. A genuinely new one is propagated.
+            if e is not exc_val:
+                raise
 
     exit_stack.clear()
     maybe_raise_exc(exc_val=exc_val, exc_tb=exc_tb, container_close_errors=errors)


### PR DESCRIPTION
## What

Fixes a scoped-resource leak during cancellation. Both `clean_exit_stack` and `async_clean_exit_stack` in `wireup/ioc/_exit_stack.py` iterated the exit stack catching only `except Exception`. `asyncio.CancelledError` (and `KeyboardInterrupt` / `SystemExit`) are `BaseException`, not `Exception`, so when a generator's `finally` re-raised the exception being unwound, it escaped the loop early — skipping cleanup of every earlier-registered generator and the `exit_stack.clear()` call.

In practice, a cancelled `async with container.enter_scope()` block (an `asyncio.wait_for` timeout, a `task.cancel()`, structured-concurrency cancellation) tore down only the **last** scoped resource and leaked the rest.

Fixes #141.

## Reproduction (before this PR)

```python
import asyncio
from collections.abc import AsyncIterator
from typing import NewType

import wireup
from wireup import injectable

A, B = NewType("A", str), NewType("B", str)
teardowns: list[str] = []

@injectable(lifetime="scoped")
async def factory_a() -> AsyncIterator[A]:
    try:
        yield A("a")
    finally:
        teardowns.append("A")

@injectable(lifetime="scoped")
async def factory_b() -> AsyncIterator[B]:
    try:
        yield B("b")
    finally:
        teardowns.append("B")

async def handler(container):
    async with container.enter_scope() as scope:
        await scope.get(A)
        await scope.get(B)
        await asyncio.sleep(10)

async def main():
    container = wireup.create_async_container(injectables=[factory_a, factory_b])
    try:
        await asyncio.wait_for(handler(container), timeout=0.05)
    except (asyncio.TimeoutError, TimeoutError):
        pass
    print(teardowns)

asyncio.run(main())
```

| | `teardowns` |
|---|---|
| before | `['B']` — `A` leaks |
| after  | `['B', 'A']` — matches `contextlib.AsyncExitStack` |

## How

Add an `except BaseException` branch after the existing `except Exception` in both cleanup loops:

```python
except BaseException as e:
    # CancelledError / KeyboardInterrupt / SystemExit are BaseException, not
    # Exception. When the exception being unwound (exc_val) re-emerges from a
    # generator's teardown, keep closing the remaining generators instead of
    # letting it abort cleanup, which would skip exit_stack.clear() and leak
    # every earlier-registered resource. A genuinely new one is propagated.
    if e is not exc_val:
        raise
```

- The re-raised `exc_val` is swallowed so cleanup of the remaining generators continues and the stack is cleared; it keeps propagating naturally through `__aexit__` afterwards (which returns `None`).
- A *new* `BaseException` raised during teardown is re-raised rather than appended to `errors`, because `ContainerCloseError` subclasses `ExceptionGroup` on Python 3.11+ and would reject non-`Exception` members.
- `async_clean_exit_stack` now trips ruff `C901` (complexity 11 > 10), so it carries a `# noqa: C901`, consistent with `factory_compiler.py` / `_wrapper_compiler.py`.

## Tests

Added to `test/unit/test_exit_stack.py`:

- `test_clean_exit_stack_continues_teardown_when_unwinding_base_exception` — sync path.
- `test_async_clean_exit_stack_continues_teardown_on_cancellation` — async path with `asyncio.CancelledError` (the reported scenario).
- `test_async_clean_exit_stack_propagates_new_base_exception_from_teardown` — locks in that a genuinely new `BaseException` still propagates.

The first two fail on `master` and pass with this change.

## Checks

`make check-ruff`, `make check-fmt`, `make check-mypy`, and `make test` (355 passed) are all green locally. No new dependencies; targets Python 3.10+.
